### PR TITLE
Raise free history event limit

### DIFF
--- a/rotkehlchen/constants/limits.py
+++ b/rotkehlchen/constants/limits.py
@@ -1,4 +1,4 @@
 from typing import Final
 
-FREE_HISTORY_EVENTS_LIMIT: Final = 100
+FREE_HISTORY_EVENTS_LIMIT: Final = 10_000_000
 FREE_USER_NOTES_LIMIT: Final = 10


### PR DESCRIPTION
## Summary
- raise the free-tier history events limit to 10,000,000 entries to match the requested configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6d4b15c0832aa11dd6d7d8f2698c