### PR TITLE
Add offline premium mode support

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -17,7 +17,7 @@ from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, Unsup
 from rotkehlchen.errors.misc import AccountingError, RemoteError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp, PriceQueryUnsupportedAsset
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import OfflinePremium, Premium
 from rotkehlchen.types import EVM_CHAIN_IDS_WITH_TRANSACTIONS, Timestamp
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.data_structures import DefaultLRUCache, LRUCacheWithRemove
@@ -72,7 +72,7 @@ class Accountant:
         self.processable_events_cache_signatures: DefaultLRUCache[int, list[int]] = DefaultLRUCache(default_factory=list, maxsize=PROCESSABLE_EVENTS_CACHE_SIZE)  # noqa: E501
         self.ignored_asset_ids: set[str] = set()  # populated in process_history so that we load them in memory once during accounting and not reload them from the DB for every single event processing  # noqa: E501
 
-    def activate_premium_status(self, premium: Premium) -> None:
+    def activate_premium_status(self, premium: Premium | OfflinePremium) -> None:
         self.premium = premium
 
     def deactivate_premium_status(self) -> None:

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3304,6 +3304,15 @@ class RestAPI:
 
     @async_api_call()
     def sync_data(self, action: Literal['upload', 'download']) -> dict[str, Any]:
+        if (
+            not self.rotkehlchen.premium_backend_enabled or
+            self.rotkehlchen.premium_sync_manager is None or
+            getattr(self.rotkehlchen.premium, 'backend_enabled', True) is False
+        ):
+            return wrap_in_fail_result(
+                'Premium backend is disabled in offline mode',
+                status_code=HTTPStatus.CONFLICT,
+            )
         try:
             success, msg = self.rotkehlchen.premium_sync_manager.sync_data(
                 action=action,

--- a/rotkehlchen/args.py
+++ b/rotkehlchen/args.py
@@ -141,5 +141,10 @@ def app_args(prog: str, description: str) -> argparse.ArgumentParser:
         help="If given then task manager won't schedule new tasks",
         action='store_true',
     )
+    p.add_argument(
+        '--offline-premium',
+        help='Disable connections to the rotki premium backend while keeping local premium features enabled',
+        action='store_true',
+    )
 
     return p

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -87,7 +87,7 @@ from rotkehlchen.externalapis.etherscan import HasChainActivity
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.premium.premium import Premium
+from rotkehlchen.premium.premium import OfflinePremium, Premium
 from rotkehlchen.types import (
     CHAINS_WITH_CHAIN_MANAGER,
     CHAINS_WITH_TRANSACTIONS_TYPE,
@@ -292,7 +292,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             msg_aggregator: MessagesAggregator,
             database: 'DBHandler',
             greenlet_manager: GreenletManager,
-            premium: Premium | None,
+            premium: Premium | OfflinePremium | None,
             data_directory: Path,
             beaconchain: 'BeaconChain',
             btc_derivation_gap_limit: int,
@@ -372,7 +372,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     def set_dot_rpc_endpoint(self, endpoint: str) -> tuple[bool, str]:
         return self.polkadot.set_rpc_endpoint(endpoint)
 
-    def activate_premium_status(self, premium: Premium) -> None:
+    def activate_premium_status(self, premium: Premium | OfflinePremium) -> None:
         self.premium = premium
         for _, module in self.iterate_modules():
             if hasattr(module, 'premium') is True:

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -132,6 +132,78 @@ UPLOAD_CHUNK_SIZE: Final = 10_000_000  # 10 MB
 MAX_UPLOAD_CHUNK_RETRIES: Final = 1
 
 
+class OfflinePremium:
+    """Local-only premium helper used when the backend is disabled."""
+
+    backend_enabled: Final[bool] = False
+    _OFFLINE_LIMITS: Final[UserLimits] = {
+        'limit_of_devices': 10,
+        'pnl_events_limit': 1_000_000,
+        'max_backup_size_mb': 5_000,
+        'history_events_limit': 1_000_000,
+        'reports_lookup_limit': 100_000,
+        'eth_staked_limit': 32_000,
+        'eth_staking_view': True,
+        'assets_graphs_view': True,
+        'statistics_view': True,
+    }
+
+    def __init__(self, msg_aggregator: 'MessagesAggregator') -> None:
+        self.msg_aggregator = msg_aggregator
+        self.status = SubscriptionStatus.ACTIVE
+        self._cached_limits: UserLimits | None = None
+        self.backend_enabled = False
+
+    @staticmethod
+    def _backend_disabled_error() -> PremiumApiError:
+        return PremiumApiError('Premium backend is disabled in offline mode')
+
+    def is_active(self) -> bool:
+        return True
+
+    def authenticate_device(self) -> None:
+        return
+
+    def fetch_limits(self) -> UserLimits:
+        if self._cached_limits is None:
+            self._cached_limits = cast(UserLimits, self._OFFLINE_LIMITS.copy())
+        return self._cached_limits
+
+    def get_capabilities(self) -> dict[str, bool]:
+        return {capability: True for capability in PREMIUM_CAPABILITIES_KEYS}
+
+    def query_premium_components(self) -> str:
+        raise self._backend_disabled_error()
+
+    def watcher_query(
+            self,
+            method: Literal['GET', 'PUT', 'PATCH', 'DELETE'],
+            data: dict[str, Any] | None,
+    ) -> Any:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+    def upload_data(
+            self,
+            data_blob: bytes,
+            our_hash: str,
+            last_modify_ts: Timestamp,
+            compression_type: Literal['zlib'],
+    ) -> None:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+    def pull_data(self) -> bytes | None:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+    def query_last_data_metadata(self) -> RemoteMetadata:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+    def get_remote_devices_information(self) -> dict:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+    def delete_device(self, device_id: str) -> None:
+        raise RemoteError('Premium backend is disabled in offline mode')
+
+
 def check_response_status_code(
         response: requests.Response,
         status_codes: Sequence[HTTPStatus],
@@ -299,6 +371,8 @@ def _decode_premium_json(response: requests.Response) -> Any:
 
 
 class Premium:
+
+    backend_enabled: Final[bool] = True
 
     def __init__(
             self,

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -94,6 +94,7 @@ from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.oracles.structures import CurrentPriceOracle
 from rotkehlchen.premium.premium import (
+    OfflinePremium,
     Premium,
     PremiumCredentials,
     has_premium_check,
@@ -151,10 +152,12 @@ class Rotkehlchen:
         """
         # Can also be None after unlock if premium credentials did not
         # authenticate or premium server temporarily offline
-        self.premium: Premium | None = None
+        self.premium: Premium | OfflinePremium | None = None
         self.user_is_logged_in: bool = False
 
         self.args = args
+        self.offline_premium_mode = self.args.offline_premium
+        self.premium_backend_enabled = not self.offline_premium_mode
         if self.args.data_dir is None:
             self.data_dir = default_data_directory()
         else:
@@ -319,10 +322,14 @@ class Rotkehlchen:
             self._perform_new_db_actions()
 
         self.data_importer = CSVDataImporter(db=self.data.db)
-        self.premium_sync_manager = PremiumSyncManager(
-            migration_manager=self.migration_manager,
-            data=self.data,
-        )
+        if self.premium_backend_enabled:
+            self.premium_sync_manager = PremiumSyncManager(
+                migration_manager=self.migration_manager,
+                data=self.data,
+            )
+        else:
+            self.premium_sync_manager = None
+            self.premium = OfflinePremium(self.msg_aggregator)
         # set the DB in the instances that need it
         self.cryptocompare.set_database(self.data.db)
         self.defillama.set_database(self.data.db)
@@ -332,25 +339,26 @@ class Rotkehlchen:
 
         # Anything that was set above here has to be cleaned in case of failure in the next step
         # by reset_after_failed_account_creation_or_login()
-        try:
-            self.premium = self.premium_sync_manager.try_premium_at_start(
-                given_premium_credentials=premium_credentials,
-                username=user,
-                create_new=create_new,
-                sync_approval=sync_approval,
-                sync_database=sync_database,
-            )
-        except PremiumAuthenticationError as e:
-            # Reraise it only if this is during the creation of a new account where
-            # the premium credentials were given by the user
-            if create_new:
-                raise
-            self.msg_aggregator.add_warning(
-                'Could not authenticate the rotki premium API keys found in the DB. '
-                f'Error: {e}. Check logs for more details',
-            )
-            # else let's just continue. User signed in successfully, but he just
-            # has unauthenticable/invalid premium credentials remaining in his DB
+        if self.premium_backend_enabled and self.premium_sync_manager is not None:
+            try:
+                self.premium = self.premium_sync_manager.try_premium_at_start(
+                    given_premium_credentials=premium_credentials,
+                    username=user,
+                    create_new=create_new,
+                    sync_approval=sync_approval,
+                    sync_database=sync_database,
+                )
+            except PremiumAuthenticationError as e:
+                # Reraise it only if this is during the creation of a new account where
+                # the premium credentials were given by the user
+                if create_new:
+                    raise
+                self.msg_aggregator.add_warning(
+                    'Could not authenticate the rotki premium API keys found in the DB. '
+                    f'Error: {e}. Check logs for more details',
+                )
+                # else let's just continue. User signed in successfully, but he just
+                # has unauthenticable/invalid premium credentials remaining in his DB
 
         with self.data.db.conn.read_ctx() as cursor:
             settings = self.get_settings(cursor)
@@ -538,6 +546,7 @@ class Rotkehlchen:
             msg_aggregator=self.msg_aggregator,
             data_updater=self.data_updater,
             username=user,
+            premium_backend_enabled=self.premium_backend_enabled,
         )
 
         self.migration_manager.maybe_migrate_data()
@@ -636,6 +645,9 @@ class Rotkehlchen:
         Raises PremiumAuthenticationError if the given key is rejected by the Rotkehlchen server
         """
         log.info('Setting new premium credentials')
+        if not self.premium_backend_enabled:
+            raise PremiumAuthenticationError('Premium backend is disabled in offline mode')
+
         if self.premium is not None:
             self.premium.set_credentials(credentials)
         else:
@@ -649,7 +661,8 @@ class Rotkehlchen:
             except RemoteError as e:
                 raise PremiumAuthenticationError(str(e)) from e
 
-        self.premium_sync_manager.premium = self.premium
+        if self.premium_sync_manager is not None:
+            self.premium_sync_manager.premium = self.premium
         self.accountant.activate_premium_status(self.premium)
         self.chains_aggregator.activate_premium_status(self.premium)
 
@@ -658,14 +671,16 @@ class Rotkehlchen:
     def deactivate_premium_status(self) -> None:
         """Deactivate premium in the current session"""
         self.premium = None
-        self.premium_sync_manager.premium = None
+        if self.premium_sync_manager is not None:
+            self.premium_sync_manager.premium = None
         self.accountant.deactivate_premium_status()
         self.chains_aggregator.deactivate_premium_status()
 
-    def activate_premium_status(self, premium: Premium) -> None:
+    def activate_premium_status(self, premium: Premium | OfflinePremium) -> None:
         """Activate premium in the current session if was deactivated"""
         self.premium = premium
-        self.premium_sync_manager.premium = self.premium
+        if self.premium_sync_manager is not None:
+            self.premium_sync_manager.premium = self.premium
         self.accountant.activate_premium_status(self.premium)
         self.chains_aggregator.activate_premium_status(self.premium)
 
@@ -1407,7 +1422,8 @@ class Rotkehlchen:
                 if len(failed_to_connect) != 0:
                     result['failed_to_connect'] = failed_to_connect
 
-                result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] = Timestamp(self.premium_sync_manager.last_remote_data_upload_ts)  # noqa: E501
+                if self.premium_sync_manager is not None:
+                    result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] = Timestamp(self.premium_sync_manager.last_remote_data_upload_ts)  # noqa: E501
         return result
 
     def shutdown(self) -> None:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -132,6 +132,7 @@ class TaskManager:
             msg_aggregator: 'MessagesAggregator',
             data_updater: 'RotkiDataUpdater',
             username: str,
+            premium_backend_enabled: bool = True,
     ) -> None:
         self.should_schedule = False
         self.max_tasks_num = max_tasks_num
@@ -172,7 +173,6 @@ class TaskManager:
             self._maybe_schedule_exchange_history_query,
             self._maybe_schedule_evm_txreceipts,
             self._maybe_decode_evm_transactions,
-            self._maybe_check_premium_status,
             self._maybe_check_data_updates,
             self._maybe_update_snapshot_balances,
             self._maybe_update_yearn_vaults,
@@ -195,7 +195,9 @@ class TaskManager:
             self._maybe_query_graph_delegated_tokens,
             self._maybe_update_pendle_cache,
         ]
-        if self.premium_sync_manager is not None:
+        if premium_backend_enabled:
+            self.potential_tasks.insert(6, self._maybe_check_premium_status)
+        if premium_backend_enabled and self.premium_sync_manager is not None:
             self.potential_tasks.append(self._maybe_schedule_db_upload)
         self.schedule_lock = gevent.lock.Semaphore()
 


### PR DESCRIPTION
## Summary
- add an `--offline-premium` flag and an offline premium stub that provides local limits and capabilities
- disable premium sync initialization, scheduler tasks, and credential updates when the backend is offline
- guard REST sync endpoints and propagate the offline premium object through accounting and chain managers

## Testing
- uv run python -m compileall rotkehlchen/args.py rotkehlchen/premium/premium.py rotkehlchen/rotkehlchen.py rotkehlchen/tasks/manager.py rotkehlchen/api/rest.py rotkehlchen/accounting/accountant.py rotkehlchen/chain/aggregator.py

------
https://chatgpt.com/codex/tasks/task_e_68de771e0bac832a84f6cc32a47c99f8