### PR TITLE
Add Windows build documentation and helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Before installing rotki, ensure you have the following dependencies:
 
 📌 **Required Software**:
 - `Node.js`
-- `npm` (Node Package Manager)
+- `pnpm`
 - `Python 3.11`
-- `uv` (Python Package Manager)
-- `Docker`
+- `uv` (Python Project Manager)
+- `Rust toolchain`
 
 ---
 
@@ -95,6 +95,7 @@ rotki supports **Windows, macOS, and Linux**.
 
 📌 **Advanced Installation** (for developers):
 - [Build from Source](https://docs.rotki.com/requirement-and-installation/build-from-source.html)
+- [Windows build from source guide](docs/windows-build.rst)
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,3 +8,4 @@ Contents
    api
    websockets
    changelog
+   windows-build

--- a/docs/windows-build.rst
+++ b/docs/windows-build.rst
@@ -1,0 +1,202 @@
+.. _windows_build:
+
+Windows build guide
+===================
+
+This guide explains how to build rotki from source on Windows 10 or Windows 11.
+It covers the required dependencies, recommended installation methods, and the
+steps to produce a working development build of the application.
+
+.. note::
+
+   All commands in this document are meant to be executed from a
+   ``PowerShell`` terminal that has been opened with standard (non-admin)
+   privileges unless explicitly stated otherwise.
+
+Prerequisites
+-------------
+
+Hardware and operating system
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Windows 10 or Windows 11 (64 bit).
+* At least 16 GB of RAM is recommended when building both the Python backend
+  and the Vue frontend simultaneously.
+
+Required software
+~~~~~~~~~~~~~~~~~
+
+The project uses a multi-language toolchain. The table below lists the minimum
+supported versions when building on Windows. Newer versions are expected to
+work as well.
+
+=============================== ===================== =======================
+Tool                            Minimum version       Notes
+=============================== ===================== =======================
+`Git <https://git-scm.com/>`_   2.44                  Required to clone the repository.
+`Node.js <https://nodejs.org/>`_ 22.0                 Needed for the Vue frontend.
+`pnpm <https://pnpm.io/>`_      10.0                  JavaScript package manager.
+`Python <https://www.python.org/>`_ 3.11             Backend language runtime.
+`uv <https://docs.astral.sh/uv/>`_ 0.4               Python project manager used for virtual environments.
+`Rust toolchain <https://www.rust-lang.org/tools/install>`_ Stable channel   Required for the Colibri service.
+`Visual Studio Build Tools <https://learn.microsoft.com/visualstudio/install/install-visual-studio>`_ 2022 build tools + "Desktop development with C++" workload Required to compile native Python/Rust dependencies.
+=============================== ===================== =======================
+
+Optional but recommended
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+* `Windows Terminal <https://learn.microsoft.com/windows/terminal/>`_ for an
+  improved shell experience.
+* `winget <https://learn.microsoft.com/windows/package-manager/winget/>`_ to
+  automate dependency installation. Most modern Windows editions have it
+  preinstalled.
+
+Automated dependency setup
+--------------------------
+
+The repository ships with helper scripts under ``tools/windows`` that can
+verify the dependency chain and install missing components via ``winget``.
+Both scripts can be inspected and customised before running them.
+
+#. Open ``PowerShell`` and clone the repository if you have not already done so::
+
+       git clone https://github.com/rotki/rotki.git
+       cd rotki
+
+#. Run the dependency checker/installer. The script will attempt to install
+   any missing tools using ``winget`` and will warn you if manual steps are
+   required (for example Visual Studio Build Tools)::
+
+       powershell -ExecutionPolicy Bypass -File tools/windows/setup-deps.ps1
+
+   You can pass ``-InstallBuildTools`` to automate the Visual Studio Build
+   Tools installation. The installation takes a while and requires elevated
+   permissions::
+
+       powershell -ExecutionPolicy Bypass -File tools/windows/setup-deps.ps1 -InstallBuildTools -Elevate
+
+   The ``-Elevate`` switch relaunches the script with administrative rights
+   because Visual Studio Build Tools need elevation.
+
+#. Once dependencies are installed, configure the project-specific
+   environments (JavaScript packages and Python virtual environment)::
+
+       powershell -ExecutionPolicy Bypass -File tools/windows/prepare-environment.ps1
+
+Manual installation alternatives
+--------------------------------
+
+If you prefer to install dependencies manually, follow the steps below.
+These should be completed before attempting to build rotki.
+
+1. Install Git by downloading the official installer from the Git website.
+2. Install Node.js 22.x from the official installer. During the installation
+   enable the option that adds Node.js to the ``PATH`` environment variable.
+3. Install pnpm using ``winget install --id pnpm.pnpm`` or by running
+   ``npm install -g pnpm`` after Node.js is available.
+4. Install Python 3.11 from the Microsoft Store or the official installer.
+   Make sure to enable the "Add python.exe to PATH" option.
+5. Install ``uv`` either via ``winget install --id Astral.UV`` or by running
+   ``pip install --user uv``.
+6. Install the Rust toolchain by running ``winget install --id Rustlang.Rustup``
+   or downloading ``rustup-init.exe`` from the official website. After
+   installation run ``rustup default stable`` to ensure you are on the stable
+   channel.
+7. Install Visual Studio 2022 Build Tools with the "Desktop development with
+   C++" workload. This provides the MSVC compiler and Windows SDK that Rust and
+   Python packages with native extensions rely on. The installation can be
+   automated with::
+
+       winget install --id Microsoft.VisualStudio.2022.BuildTools --override "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --quiet --wait"
+
+Fetching the source code
+------------------------
+
+Use Git to clone the repository and switch into its directory::
+
+    git clone https://github.com/rotki/rotki.git
+    cd rotki
+
+If you plan to contribute back, fork the repository first and clone your fork.
+
+Bootstrapping the development environment
+-----------------------------------------
+
+After all dependencies are installed, initialise the project dependencies.
+The PowerShell helper script ``tools/windows/prepare-environment.ps1`` runs the
+necessary commands for you, but the steps are listed here explicitly.
+
+1. Install frontend packages::
+
+       pnpm install
+
+2. Create and synchronise the Python environment using ``uv``::
+
+       uv sync
+
+3. (Optional) Verify the Rust toolchain::
+
+       rustup show active-toolchain
+       cargo --version
+
+Running the development servers
+-------------------------------
+
+Once dependencies are installed and the environment is prepared you can launch
+both the backend and the frontend.
+
+1. Start the backend API and WebSocket server::
+
+       uv run python -m rotkehlchen --api-port 4242 --websockets-port 4333
+
+2. In a new ``PowerShell`` window, start the frontend development server from
+   the ``frontend`` directory::
+
+       cd frontend
+       pnpm dev
+
+The application will open in Electron by default. You can also run the web-only
+frontend using ``pnpm dev:web``.
+
+Building distributable artifacts
+--------------------------------
+
+To build a production version of the frontend run::
+
+    cd frontend
+    pnpm build
+
+For packaging the desktop application, ensure all platform-specific
+requirements are installed (including ``electron-builder`` dependencies) and
+run::
+
+    cd ..
+    python package.py
+
+Running automated tests
+-----------------------
+
+Backend tests should always be executed through the provided test wrapper to
+ensure gevent is initialised correctly::
+
+    uv run python pytestgeventwrapper.py
+
+Frontend unit tests run via pnpm::
+
+    cd frontend
+    pnpm test:unit
+
+Troubleshooting
+---------------
+
+* If ``winget`` is not installed, install the Windows App Installer from the
+  Microsoft Store and rerun the dependency script.
+* If pnpm cannot find the Python executable, ensure that ``python.exe`` is on
+  your ``PATH`` and restart the shell.
+* If Rust compilation fails complaining about the MSVC toolchain, open the
+  "x64 Native Tools Command Prompt for VS 2022", run ``rustup default stable``
+  again, and retry the build.
+* When ``uv`` fails to build a Python package because of missing build tools,
+  confirm that the "Desktop development with C++" workload was installed and
+  reboot Windows after installing Visual Studio Build Tools.
+

--- a/tools/windows/prepare-environment.ps1
+++ b/tools/windows/prepare-environment.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [switch]$SkipFrontend,
+    [switch]$SkipPython,
+    [switch]$SkipRustCheck
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Message,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+
+    Write-Host "==> $Message" -ForegroundColor Cyan
+    & $Action
+    Write-Host "   Completed." -ForegroundColor Green
+}
+
+function Resolve-RepositoryRoot {
+    $toolsDir = Split-Path -Path $PSScriptRoot -Parent
+    return Split-Path -Path $toolsDir -Parent
+}
+
+$repoRoot = Resolve-RepositoryRoot
+Set-Location $repoRoot
+
+Write-Host "Working directory: $repoRoot" -ForegroundColor Cyan
+
+if (-not $SkipFrontend) {
+    Invoke-Step 'Installing JavaScript dependencies (pnpm install)' {
+        pnpm install
+    }
+}
+
+if (-not $SkipPython) {
+    Invoke-Step 'Synchronising Python environment (uv sync)' {
+        uv sync
+    }
+}
+
+if (-not $SkipRustCheck) {
+    if (Get-Command rustup -ErrorAction SilentlyContinue) {
+        Invoke-Step 'Verifying active Rust toolchain' {
+            $toolchain = rustup show active-toolchain
+            if ($toolchain) {
+                Write-Host "   $toolchain" -ForegroundColor DarkCyan
+            } else {
+                Write-Host '   Unable to determine the active toolchain.' -ForegroundColor Yellow
+            }
+        }
+    } else {
+        Write-Warning 'rustup not found. Run tools/windows/setup-deps.ps1 to install the Rust toolchain.'
+    }
+}
+
+Write-Host 'Environment preparation completed. You can now run pnpm dev or uv run python -m rotkehlchen.' -ForegroundColor Yellow
+

--- a/tools/windows/setup-deps.ps1
+++ b/tools/windows/setup-deps.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [switch]$InstallBuildTools,
+    [switch]$Elevate,
+    [switch]$Reinvoked
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-IsAdministrator {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if ($Elevate -and -not (Test-IsAdministrator)) {
+    if ($Reinvoked) {
+        throw 'Elevation failed. Please rerun this script from an elevated PowerShell session.'
+    }
+
+    Write-Host 'Requesting elevation...' -ForegroundColor Cyan
+    $arguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$PSCommandPath`"")
+    if ($InstallBuildTools) {
+        $arguments += '-InstallBuildTools'
+    }
+    $arguments += '-Reinvoked'
+    Start-Process -FilePath 'powershell' -ArgumentList $arguments -Verb RunAs -Wait
+    return
+}
+
+if ($InstallBuildTools -and -not (Test-IsAdministrator)) {
+    Write-Warning 'Installing Visual Studio Build Tools usually requires administrative privileges. Rerun with -Elevate or from an elevated PowerShell session if the installation fails.'
+}
+
+function Assert-Winget {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        throw 'winget is required for automatic installation. Install the Windows App Installer from the Microsoft Store and rerun the script.'
+    }
+}
+
+function Invoke-WingetInstall {
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [string]$OverrideArguments
+    )
+
+    Assert-Winget
+    $args = @('install', '--id', $Id, '--exact', '--accept-source-agreements', '--accept-package-agreements')
+    if ($OverrideArguments) {
+        $args += @('--override', $OverrideArguments)
+    }
+    Write-Host "Installing $Id via winget..." -ForegroundColor Cyan
+    $process = Start-Process -FilePath 'winget' -ArgumentList $args -NoNewWindow -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+        throw "winget installation for $Id failed with exit code $($process.ExitCode)."
+    }
+}
+
+function Get-FirstVersionFromString {
+    param([Parameter(Mandatory = $true)][string]$Input)
+
+    $match = [regex]::Match($Input, '(\d+(?:\.\d+){0,3})')
+    if ($match.Success) {
+        return [version]$match.Value
+    }
+    return $null
+}
+
+function Test-CommandVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [string[]]$Arguments,
+        [version]$MinimumVersion
+    )
+
+    $executable = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $executable) {
+        return @{ Present = $false; Version = $null; MeetsRequirement = $false }
+    }
+
+    $output = & $Command @Arguments 2>$null
+    $version = if ($output) { Get-FirstVersionFromString ($output | Out-String) } else { $null }
+    $meetsRequirement = $false
+    if ($MinimumVersion -and $version) {
+        $meetsRequirement = $version -ge $MinimumVersion
+    } elseif (-not $MinimumVersion) {
+        $meetsRequirement = $true
+    }
+
+    return @{ Present = $true; Version = $version; MeetsRequirement = $meetsRequirement }
+}
+
+$dependencies = @(
+    @{ Name = 'Git'; Command = 'git'; Args = @('--version'); Minimum = [version]'2.44'; WingetId = 'Git.Git' },
+    @{ Name = 'Node.js'; Command = 'node'; Args = @('--version'); Minimum = [version]'22.0'; WingetId = 'OpenJS.NodeJS' },
+    @{ Name = 'pnpm'; Command = 'pnpm'; Args = @('--version'); Minimum = [version]'10.0'; WingetId = 'pnpm.pnpm' },
+    @{ Name = 'Python'; Command = 'python'; Args = @('--version'); Minimum = [version]'3.11'; WingetId = 'Python.Python.3.11' },
+    @{ Name = 'uv'; Command = 'uv'; Args = @('--version'); Minimum = [version]'0.4'; WingetId = 'Astral.UV' },
+    @{ Name = 'rustc'; Command = 'rustc'; Args = @('--version'); Minimum = [version]'1.75'; WingetId = 'Rustlang.Rustup' }
+)
+
+foreach ($dependency in $dependencies) {
+    Write-Host "Checking $($dependency.Name)..." -ForegroundColor Cyan
+    $result = Test-CommandVersion -Command $dependency.Command -Arguments $dependency.Args -MinimumVersion $dependency.Minimum
+
+    if (-not $result.Present -or -not $result.MeetsRequirement) {
+        if ($result.Present -and $result.Version) {
+            Write-Warning "$($dependency.Name) version $($result.Version) is below the required $($dependency.Minimum)."
+        } elseif (-not $result.Present) {
+            Write-Warning "$($dependency.Name) is not installed."
+        }
+
+        if ($dependency.WingetId) {
+            Invoke-WingetInstall -Id $dependency.WingetId
+            $result = Test-CommandVersion -Command $dependency.Command -Arguments $dependency.Args -MinimumVersion $dependency.Minimum
+            if ($result.Present -and $result.MeetsRequirement) {
+                Write-Host "  Installed version $($result.Version)." -ForegroundColor Green
+            } else {
+                Write-Warning "Unable to verify $($dependency.Name) after installation. Please check manually."
+            }
+        } else {
+            Write-Warning "No automatic installation configured for $($dependency.Name). Please install it manually."
+        }
+    } else {
+        Write-Host "  Found version $($result.Version)." -ForegroundColor Green
+    }
+
+}
+
+if ($InstallBuildTools) {
+    Write-Host 'Ensuring Visual Studio Build Tools (Desktop development with C++) are installed...' -ForegroundColor Cyan
+    Invoke-WingetInstall -Id 'Microsoft.VisualStudio.2022.BuildTools' -OverrideArguments '--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --passive --wait --locale en-US'
+    Write-Host 'Visual Studio Build Tools installation complete. A reboot may be required before building native dependencies.' -ForegroundColor Yellow
+} else {
+    Write-Host 'Visual Studio Build Tools are required for compiling native code. Run this script with -InstallBuildTools to install them automatically.' -ForegroundColor Yellow
+}
+
+Write-Host 'Dependency check completed.' -ForegroundColor Green
+


### PR DESCRIPTION
## Summary
- document building rotki from source on Windows, including dependency installation guidance
- add PowerShell scripts to verify/install dependencies and bootstrap the project on Windows
- link the new guide from the README and Sphinx table of contents

## Testing
- make -C docs html *(fails: `sphinx-build` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e42f03869c832a990289e825dda413