### PR TITLE
Add telemetry aggregation and settings dashboard

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,5 +7,6 @@ Contents
 
    api
    websockets
+   telemetry-dashboard
    changelog
    windows-build

--- a/docs/telemetry-dashboard.rst
+++ b/docs/telemetry-dashboard.rst
@@ -1,0 +1,32 @@
+Telemetry dashboard
+===================
+
+The telemetry dashboard surfaces recent networking activity captured by rotki.
+It combines HTTP requests, WebSocket broadcasts, and VPN probes into a single
+view so you can audit connectivity problems or latency spikes at a glance.
+
+Opening the dashboard
+---------------------
+
+1. Unlock rotki and wait for the periodic monitor to finish its initial poll.
+2. Open :menuselection:`Settings -> Telemetry` in the application sidebar.
+3. The page automatically refreshes whenever new telemetry batches arrive from
+   the backend periodic query.
+
+Working with the data
+---------------------
+
+* **Filters** – Narrow results by direction (inbound or outbound), subsystem
+  (HTTP, WebSocket, or VPN), and routing path. Use the search box to match
+  endpoints or hosts.
+* **Latency column** – Displays the measured request or message round trip in
+  milliseconds. High values highlight potential congestion or slow upstream
+  services.
+* **Status column** – Shows HTTP status codes, transport errors, or VPN probe
+  failures. Hover over table rows in the UI to view the complete endpoint.
+
+Data retention
+--------------
+
+The dashboard presents the 100 most recent events kept in memory for the
+current session. Signing out or restarting rotki clears the buffer.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3515,7 +3515,8 @@
       "interface": "Interface-only",
       "modules": "Modules",
       "oracles": "Oracles",
-      "rpc_nodes": "RPC Nodes"
+      "rpc_nodes": "RPC Nodes",
+      "telemetry": "Network telemetry"
     },
     "staking": "Staking",
     "statistics": "Statistics",
@@ -3525,6 +3526,41 @@
     },
     "tag_manager": "Tag Manager",
     "wallet_bridge": "Wallet Bridge"
+  },
+  "telemetry": {
+    "title": "Network telemetry",
+    "subtitle": "Inspect recent networking activity captured across rotki.",
+    "filters": {
+      "title": "Filters",
+      "search": "Search",
+      "search_placeholder": "Filter by endpoint or route",
+      "direction": "Direction",
+      "direction_all": "All directions",
+      "direction_outbound": "Outbound",
+      "direction_inbound": "Inbound",
+      "subsystem": "Subsystem",
+      "subsystem_all": "All subsystems",
+      "route": "Route",
+      "route_all": "All routes"
+    },
+    "status": {
+      "failed": "Failed",
+      "success": "Success"
+    },
+    "table": {
+      "title": "Recent telemetry",
+      "headers": {
+        "timestamp": "Timestamp",
+        "subsystem": "Subsystem",
+        "direction": "Direction",
+        "endpoint": "Endpoint",
+        "route": "Route",
+        "latency": "Latency",
+        "status": "Status"
+      },
+      "direct_route": "Direct",
+      "empty": "No telemetry has been recorded yet."
+    }
   },
   "net_worth_chart": {
     "current_balance": "Current balance"

--- a/frontend/app/src/pages/settings.vue
+++ b/frontend/app/src/pages/settings.vue
@@ -20,6 +20,7 @@ const tabs = computed<TabContent[]>(() => {
     Routes.SETTINGS_ACCOUNTING,
     Routes.SETTINGS_ORACLE,
     Routes.SETTINGS_RPC,
+    Routes.SETTINGS_TELEMETRY,
     Routes.SETTINGS_MODULES,
     Routes.SETTINGS_INTERFACE,
   ];

--- a/frontend/app/src/pages/settings/telemetry/index.vue
+++ b/frontend/app/src/pages/settings/telemetry/index.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import dayjs from 'dayjs';
+import '@/utils/date';
+import SettingsPage from '@/components/settings/controls/SettingsPage.vue';
+import SettingCategory from '@/components/settings/SettingCategory.vue';
+import SimpleTable from '@/components/common/SimpleTable.vue';
+import { usePeriodicStore } from '@/store/session/periodic';
+import type { TelemetryEvent } from '@/types/session';
+
+definePage({});
+
+const { t } = useI18n({ useScope: 'global' });
+const periodicStore = usePeriodicStore();
+const { telemetry } = storeToRefs(periodicStore);
+
+const search = ref('');
+const directionFilter = ref<'all' | TelemetryEvent['direction']>('all');
+const subsystemFilter = ref<'all' | TelemetryEvent['subsystem']>('all');
+const routeFilter = ref<'all' | string>('all');
+
+const routeOptions = computed(() => {
+  const routes = new Set<string>();
+  for (const entry of telemetry.value) {
+    if (entry.route)
+      routes.add(entry.route);
+  }
+  return ['all', ...Array.from(routes).sort()];
+});
+
+const filteredTelemetry = computed(() => {
+  const query = search.value.trim().toLowerCase();
+  const direction = directionFilter.value;
+  const subsystem = subsystemFilter.value;
+  const route = routeFilter.value;
+
+  return telemetry.value
+    .filter((event) => {
+      if (direction !== 'all' && event.direction !== direction)
+        return false;
+      if (subsystem !== 'all' && event.subsystem !== subsystem)
+        return false;
+      if (route !== 'all' && (event.route ?? 'direct') !== route)
+        return false;
+      if (!query)
+        return true;
+
+      const haystack = `${event.endpoint} ${event.route ?? ''} ${event.subsystem}`.toLowerCase();
+      return haystack.includes(query);
+    })
+    .sort((a, b) => b.timestamp - a.timestamp);
+});
+
+const hasTelemetry = computed(() => filteredTelemetry.value.length > 0);
+
+function formatTimestamp(timestamp: number): string {
+  return dayjs(timestamp).format('LLL');
+}
+
+function formatLatency(latencyMs: number): string {
+  return `${latencyMs.toFixed(2)} ms`;
+}
+
+function formatStatus(event: TelemetryEvent): string {
+  if (event.error)
+    return event.error;
+  if (event.statusCode !== null && event.statusCode !== undefined)
+    return `${event.statusCode}${event.success ? '' : ' ⚠️'}`;
+
+  return event.success ? t('telemetry.status.success') : t('telemetry.status.failed');
+}
+
+onMounted(() => {
+  void periodicStore.check();
+});
+</script>
+
+<template>
+  <SettingsPage>
+    <SettingCategory>
+      <template #title>
+        {{ t('telemetry.title') }}
+      </template>
+      <template #subtitle>
+        {{ t('telemetry.subtitle') }}
+      </template>
+      <div class="flex flex-col gap-6 pt-6">
+        <div class="border border-default rounded-lg p-4 md:p-6 space-y-4">
+          <h6 class="text-h6 font-semibold">
+            {{ t('telemetry.filters.title') }}
+          </h6>
+          <div class="grid gap-4 md:grid-cols-4">
+            <label class="flex flex-col gap-2">
+              <span class="text-caption text-rui-grey-600 dark:text-rui-grey-400">
+                {{ t('telemetry.filters.search') }}
+              </span>
+              <input
+                v-model="search"
+                type="search"
+                class="rui-input"
+                :placeholder="t('telemetry.filters.search_placeholder')"
+                data-cy="telemetry-filter-search"
+              >
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-caption text-rui-grey-600 dark:text-rui-grey-400">
+                {{ t('telemetry.filters.direction') }}
+              </span>
+              <select
+                v-model="directionFilter"
+                class="rui-input"
+                data-cy="telemetry-filter-direction"
+              >
+                <option value="all">
+                  {{ t('telemetry.filters.direction_all') }}
+                </option>
+                <option value="outbound">
+                  {{ t('telemetry.filters.direction_outbound') }}
+                </option>
+                <option value="inbound">
+                  {{ t('telemetry.filters.direction_inbound') }}
+                </option>
+              </select>
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-caption text-rui-grey-600 dark:text-rui-grey-400">
+                {{ t('telemetry.filters.subsystem') }}
+              </span>
+              <select
+                v-model="subsystemFilter"
+                class="rui-input"
+                data-cy="telemetry-filter-subsystem"
+              >
+                <option value="all">
+                  {{ t('telemetry.filters.subsystem_all') }}
+                </option>
+                <option value="http">
+                  HTTP
+                </option>
+                <option value="websocket">
+                  WebSocket
+                </option>
+                <option value="vpn">
+                  VPN
+                </option>
+              </select>
+            </label>
+            <label class="flex flex-col gap-2">
+              <span class="text-caption text-rui-grey-600 dark:text-rui-grey-400">
+                {{ t('telemetry.filters.route') }}
+              </span>
+              <select
+                v-model="routeFilter"
+                class="rui-input"
+                data-cy="telemetry-filter-route"
+              >
+                <option
+                  v-for="option in routeOptions"
+                  :key="option"
+                  :value="option"
+                >
+                  {{ option === 'all' ? t('telemetry.filters.route_all') : option }}
+                </option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div class="border border-default rounded-lg overflow-hidden">
+          <div class="border-b border-default bg-rui-grey-50 dark:bg-[#1a1a1a] p-4">
+            <h6 class="text-h6 font-semibold">
+              {{ t('telemetry.table.title') }}
+            </h6>
+          </div>
+          <div class="p-4 overflow-x-auto">
+            <template v-if="hasTelemetry">
+              <SimpleTable class="min-w-[720px]">
+                <thead>
+                  <tr>
+                    <th class="text-left">{{ t('telemetry.table.headers.timestamp') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.subsystem') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.direction') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.endpoint') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.route') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.latency') }}</th>
+                    <th class="text-left">{{ t('telemetry.table.headers.status') }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="event in filteredTelemetry"
+                    :key="`${event.timestamp}-${event.endpoint}-${event.subsystem}`"
+                    data-cy="telemetry-row"
+                  >
+                    <td>{{ formatTimestamp(event.timestamp) }}</td>
+                    <td class="capitalize">{{ event.subsystem }}</td>
+                    <td class="capitalize">{{ event.direction }}</td>
+                    <td class="break-all">{{ event.endpoint }}</td>
+                    <td>{{ event.route ?? t('telemetry.table.direct_route') }}</td>
+                    <td>{{ formatLatency(event.latencyMs) }}</td>
+                    <td>{{ formatStatus(event) }}</td>
+                  </tr>
+                </tbody>
+              </SimpleTable>
+            </template>
+            <p
+              v-else
+              class="text-sm text-rui-grey-600 dark:text-rui-grey-400"
+              data-cy="telemetry-empty"
+            >
+              {{ t('telemetry.table.empty') }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </SettingCategory>
+  </SettingsPage>
+</template>

--- a/frontend/app/src/router/routes.ts
+++ b/frontend/app/src/router/routes.ts
@@ -57,6 +57,7 @@ export const Routes = {
   SETTINGS_MODULES: ensureRoute('/settings/modules'),
   SETTINGS_ORACLE: ensureRoute('/settings/oracle'),
   SETTINGS_RPC: ensureRoute('/settings/rpc'),
+  SETTINGS_TELEMETRY: ensureRoute('/settings/telemetry'),
   STAKING: ensureRoute('/staking/:location*'),
   STATISTICS: ensureRoute('/statistics'),
   STATISTICS_GRAPHS: ensureRoute('/statistics/graphs'),
@@ -307,6 +308,11 @@ export const useAppRoutes = createSharedComposable(() => {
       icon: 'lu-wifi' as const,
       route: Routes.SETTINGS_RPC,
       text: t('navigation_menu.settings_sub.rpc_nodes'),
+    },
+    SETTINGS_TELEMETRY: {
+      icon: 'lu-activity' as const,
+      route: Routes.SETTINGS_TELEMETRY,
+      text: t('navigation_menu.settings_sub.telemetry'),
     },
     STAKING: {
       icon: 'lu-layers' as const,

--- a/frontend/app/src/store/session/periodic.ts
+++ b/frontend/app/src/store/session/periodic.ts
@@ -1,6 +1,7 @@
 import { backoff } from '@shared/utils';
 import { useSessionApi } from '@/composables/api/session';
 import { useNotificationsStore } from '@/store/notifications';
+import type { TelemetryEvent } from '@/types/session';
 
 export const usePeriodicStore = defineStore('session/periodic', () => {
   const lastBalanceSave = ref(0);
@@ -8,6 +9,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
   const connectedNodes = ref<Record<string, string[]>>({});
   const failedToConnect = ref<Record<string, string[]>>({});
   const periodicRunning = ref(false);
+  const telemetry = ref<TelemetryEvent[]>([]);
 
   const { notify } = useNotificationsStore();
   const { t } = useI18n({ useScope: 'global' });
@@ -30,6 +32,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
         failedToConnect: failed,
         lastBalanceSave: balance,
         lastDataUploadTs: upload,
+        telemetry: telemetryEvents,
       } = result;
 
       if (get(lastBalanceSave) !== balance)
@@ -40,6 +43,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
 
       set(connectedNodes, connected);
       set(failedToConnect, failed);
+      set(telemetry, telemetryEvents);
     }
     catch (error: any) {
       notify({
@@ -61,6 +65,7 @@ export const usePeriodicStore = defineStore('session/periodic', () => {
     failedToConnect,
     lastBalanceSave,
     lastDataUpload,
+    telemetry,
   };
 });
 

--- a/frontend/app/src/types/session/index.ts
+++ b/frontend/app/src/types/session/index.ts
@@ -3,11 +3,27 @@ import type { CamelCase } from '@/types/common';
 import type { Module } from '@/types/modules';
 import { z } from 'zod/v4';
 
+export const TelemetryEvent = z.object({
+  timestamp: z.number(),
+  direction: z.enum(['inbound', 'outbound']),
+  subsystem: z.enum(['http', 'websocket', 'vpn']),
+  endpoint: z.string(),
+  route: z.string().nullable(),
+  latencyMs: z.number(),
+  statusCode: z.number().nullable(),
+  success: z.boolean(),
+  error: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type TelemetryEvent = z.infer<typeof TelemetryEvent>;
+
 export const PeriodicClientQueryResult = z.object({
   connectedNodes: z.record(z.string(), z.array(z.string())),
   failedToConnect: z.record(z.string(), z.array(z.string())).optional(),
   lastBalanceSave: z.number(),
   lastDataUploadTs: z.number(),
+  telemetry: z.array(TelemetryEvent),
 });
 
 export type PeriodicClientQueryResult = z.infer<typeof PeriodicClientQueryResult>;

--- a/frontend/app/tests/unit/specs/pages/settings/telemetry.spec.ts
+++ b/frontend/app/tests/unit/specs/pages/settings/telemetry.spec.ts
@@ -1,0 +1,84 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { createPinia, setActivePinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TelemetrySettingsPage from '@/pages/settings/telemetry/index.vue';
+import { usePeriodicStore } from '@/store/session/periodic';
+
+const fetchPeriodicData = vi.fn();
+
+vi.mock('@/composables/api/session', () => ({
+  useSessionApi: () => ({
+    fetchPeriodicData,
+  }),
+}));
+
+vi.mock('@shared/utils', () => ({
+  backoff: (_retries: number, call: () => Promise<any>) => call(),
+}));
+
+describe('settings telemetry page', () => {
+  beforeEach(() => {
+    fetchPeriodicData.mockReset();
+  });
+
+  it('renders telemetry rows and filters by search', async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+
+    const telemetrySample = [
+      {
+        direction: 'outbound',
+        endpoint: 'https://example.com/api',
+        error: null,
+        latencyMs: 8.5,
+        metadata: {},
+        route: 'direct',
+        statusCode: 200,
+        subsystem: 'http',
+        success: true,
+        timestamp: 1700000000000,
+      },
+      {
+        direction: 'inbound',
+        endpoint: 'broadcast:status',
+        error: null,
+        latencyMs: 2.1,
+        metadata: {},
+        route: 'vpn-route',
+        statusCode: null,
+        subsystem: 'websocket',
+        success: true,
+        timestamp: 1700000000500,
+      },
+    ];
+
+    fetchPeriodicData.mockResolvedValue({
+      connectedNodes: {},
+      failedToConnect: {},
+      lastBalanceSave: 0,
+      lastDataUploadTs: 0,
+      telemetry: telemetrySample,
+    });
+
+    const wrapper = mount(TelemetrySettingsPage, {
+      pinia,
+      global: {
+        provide: libraryDefaults,
+      },
+    });
+
+    await flushPromises();
+    const store = usePeriodicStore();
+    expect(store.telemetry).toHaveLength(2);
+
+    const rows = wrapper.findAll('[data-cy="telemetry-row"]');
+    expect(rows).toHaveLength(2);
+
+    const searchInput = wrapper.find('input[data-cy="telemetry-filter-search"]');
+    await searchInput.setValue('broadcast');
+    await flushPromises();
+    expect(wrapper.findAll('[data-cy="telemetry-row"]').length).toBe(1);
+  });
+});

--- a/frontend/app/tests/unit/specs/store/session/periodic.spec.ts
+++ b/frontend/app/tests/unit/specs/store/session/periodic.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { usePeriodicStore } from '@/store/session/periodic';
+
+const fetchPeriodicData = vi.fn();
+
+vi.mock('@/composables/api/session', () => ({
+  useSessionApi: () => ({
+    fetchPeriodicData,
+  }),
+}));
+
+vi.mock('@shared/utils', () => ({
+  backoff: (_retries: number, call: () => Promise<any>) => call(),
+}));
+
+describe('session periodic store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    fetchPeriodicData.mockReset();
+  });
+
+  it('stores telemetry payload', async () => {
+    const store = usePeriodicStore();
+    fetchPeriodicData.mockResolvedValue({
+      connectedNodes: {},
+      failedToConnect: {},
+      lastBalanceSave: 10,
+      lastDataUploadTs: 20,
+      telemetry: [
+        {
+          direction: 'outbound',
+          endpoint: 'https://example.com/api',
+          error: null,
+          latencyMs: 12.5,
+          metadata: {},
+          route: 'direct',
+          statusCode: 200,
+          subsystem: 'http',
+          success: true,
+          timestamp: 1700000000000,
+        },
+      ],
+    });
+
+    await store.check();
+    expect(fetchPeriodicData).toHaveBeenCalledTimes(1);
+    expect(store.telemetry).toHaveLength(1);
+    expect(store.telemetry[0].endpoint).toBe('https://example.com/api');
+  });
+});

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -3,6 +3,7 @@ import json
 import logging
 from collections.abc import Callable
 from contextlib import suppress
+from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from gevent.lock import Semaphore
@@ -12,6 +13,7 @@ from geventwebsocket.websocket import WebSocket
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.serialize import process_result
+from rotkehlchen.telemetry import telemetry_collector
 
 if TYPE_CHECKING:
     from rotkehlchen.api.websockets.typedefs import WSMessageType
@@ -89,6 +91,7 @@ class RotkiNotifier:
 
         to_remove_indices = set()
         spawned_one_broadcast = False
+        start_time = perf_counter()
         for idx, websocket in enumerate(self.subscribers):
             if websocket.closed is True:
                 to_remove_indices.add(idx)
@@ -112,6 +115,15 @@ class RotkiNotifier:
         if spawned_one_broadcast is False and failure_callback is not None:
             failure_callback_args = {} if failure_callback_args is None else failure_callback_args
             failure_callback(**failure_callback_args)
+
+        telemetry_collector.record_event(
+            subsystem='websocket',
+            direction='outbound',
+            endpoint=str(message_type),
+            latency_ms=(perf_counter() - start_time) * 1000,
+            success=spawned_one_broadcast,
+            metadata={'subscribers': len(self.subscribers)},
+        )
 
 
 class RotkiWSApp(WebSocketApplication):

--- a/rotkehlchen/networking/__init__.py
+++ b/rotkehlchen/networking/__init__.py
@@ -1,0 +1,5 @@
+"""Networking utilities for rotkehlchen."""
+
+from .vpn import VPNManager
+
+__all__ = ['VPNManager']

--- a/rotkehlchen/networking/vpn.py
+++ b/rotkehlchen/networking/vpn.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from gevent.lock import Semaphore
+
+from rotkehlchen.telemetry import telemetry_collector
+
+
+@dataclass(slots=True)
+class VPNRoute:
+    """Represents the active VPN routing path."""
+
+    name: str
+
+
+class VPNManager:
+    """Lightweight manager storing VPN routing state and emitting telemetry."""
+
+    _DEFAULT_ROUTE: Final[str] = 'direct'
+
+    def __init__(self) -> None:
+        self._lock = Semaphore()
+        self._route = VPNRoute(self._DEFAULT_ROUTE)
+        telemetry_collector.update_route(self._DEFAULT_ROUTE)
+
+    @property
+    def route(self) -> str:
+        with self._lock:
+            return self._route.name
+
+    def update_route(self, route: str | None) -> None:
+        """Update the active VPN route and propagate the hint to telemetry."""
+        normalized = route or self._DEFAULT_ROUTE
+        with self._lock:
+            self._route = VPNRoute(normalized)
+        telemetry_collector.update_route(normalized)
+
+    def record_probe(self, endpoint: str, latency_ms: float, success: bool, error: str | None = None) -> None:
+        """Record a telemetry event for a VPN probe or tunnel action."""
+        telemetry_collector.record_event(
+            subsystem='vpn',
+            direction='outbound',
+            endpoint=endpoint,
+            latency_ms=latency_ms,
+            success=success,
+            error=error,
+            metadata={'route': self.route},
+            route=self.route,
+        )

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -94,6 +94,7 @@ from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.icons import IconManager
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.networking import VPNManager
 from rotkehlchen.oracles.structures import CurrentPriceOracle
 from rotkehlchen.premium.premium import (
     OfflinePremium,
@@ -125,6 +126,7 @@ from rotkehlchen.types import (
     SupportedBlockchain,
     Timestamp,
 )
+from rotkehlchen.telemetry import TelemetryQueue, telemetry_collector
 from rotkehlchen.usage_analytics import maybe_submit_usage_analytics
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.datadir import maybe_restructure_rotki_data_directory
@@ -181,6 +183,9 @@ class Rotkehlchen:
         self.greenlet_manager = GreenletManager(msg_aggregator=self.msg_aggregator)
         self.rotki_notifier = RotkiNotifier()
         self.msg_aggregator.rotki_notifier = self.rotki_notifier
+        self.telemetry: TelemetryQueue = TelemetryQueue()
+        telemetry_collector.set_queue(self.telemetry)
+        self.vpn_manager = VPNManager()
         self.exchange_manager = ExchangeManager(msg_aggregator=self.msg_aggregator)
         if self.dev_unlock_all_enabled:
             self.premium = OfflinePremium(self.msg_aggregator)
@@ -1435,10 +1440,13 @@ class Rotkehlchen:
 
                 if self.premium_sync_manager is not None:
                     result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] = Timestamp(self.premium_sync_manager.last_remote_data_upload_ts)  # noqa: E501
+
+                result['telemetry'] = self.telemetry.dump(limit=100)
         return result
 
     def shutdown(self) -> None:
         self.logout()
+        telemetry_collector.set_queue(None)
         self.shutdown_event.set()
 
     def create_oracle_cache(

--- a/rotkehlchen/telemetry/__init__.py
+++ b/rotkehlchen/telemetry/__init__.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Final, Literal
+
+from gevent.lock import Semaphore
+
+from rotkehlchen.types import TimestampMS
+from rotkehlchen.utils.misc import ts_now_in_ms
+
+TelemetryDirection = Literal['inbound', 'outbound']
+TelemetrySubsystem = Literal['http', 'websocket', 'vpn']
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Represents a single telemetry datapoint for networking activity."""
+
+    timestamp: TimestampMS
+    direction: TelemetryDirection
+    subsystem: TelemetrySubsystem
+    endpoint: str
+    route: str | None
+    latency_ms: float
+    status_code: int | None = None
+    success: bool = True
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def serialize(self) -> dict[str, Any]:
+        """Return a JSON serializable representation of the event."""
+        return {
+            'timestamp': int(self.timestamp),
+            'direction': self.direction,
+            'subsystem': self.subsystem,
+            'endpoint': self.endpoint,
+            'route': self.route,
+            'latency_ms': float(self.latency_ms),
+            'status_code': self.status_code,
+            'success': self.success,
+            'error': self.error,
+            'metadata': self.metadata or {},
+        }
+
+
+class TelemetryQueue:
+    """A bounded queue storing the most recent telemetry events."""
+
+    def __init__(self, maxlen: int = 500) -> None:
+        self._events: deque[TelemetryEvent] = deque(maxlen=maxlen)
+        self._lock = Semaphore()
+
+    def add_event(self, event: TelemetryEvent) -> None:
+        with self._lock:
+            self._events.append(event)
+
+    def extend(self, events: list[TelemetryEvent]) -> None:
+        with self._lock:
+            self._events.extend(events)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+    def get_recent(self, limit: int | None = None) -> list[TelemetryEvent]:
+        with self._lock:
+            if limit is None or limit >= len(self._events):
+                return list(self._events)
+            return list(self._events)[-limit:]
+
+    def dump(self, limit: int | None = None) -> list[dict[str, Any]]:
+        return [event.serialize() for event in self.get_recent(limit=limit)]
+
+
+class TelemetryCollector:
+    """Collects telemetry events from subsystems and routes them to a queue."""
+
+    _DEFAULT_ROUTE: Final[str] = 'direct'
+
+    def __init__(self) -> None:
+        self._queue: TelemetryQueue | None = None
+        self._route_hint: str = self._DEFAULT_ROUTE
+        self._lock = Semaphore()
+
+    def set_queue(self, queue: TelemetryQueue | None) -> None:
+        with self._lock:
+            self._queue = queue
+
+    def update_route(self, route: str | None) -> None:
+        with self._lock:
+            self._route_hint = route or self._DEFAULT_ROUTE
+
+    def record_event(
+            self,
+            *,
+            subsystem: TelemetrySubsystem,
+            direction: TelemetryDirection,
+            endpoint: str,
+            latency_ms: float,
+            success: bool,
+            status_code: int | None = None,
+            error: str | None = None,
+            metadata: dict[str, Any] | None = None,
+            route: str | None = None,
+    ) -> None:
+        queue = self._queue
+        if queue is None:
+            return
+
+        with self._lock:
+            resolved_route = route or self._route_hint
+
+        event = TelemetryEvent(
+            timestamp=ts_now_in_ms(),
+            direction=direction,
+            subsystem=subsystem,
+            endpoint=endpoint,
+            route=resolved_route,
+            latency_ms=latency_ms,
+            status_code=status_code,
+            success=success,
+            error=error,
+            metadata=metadata or {},
+        )
+        queue.add_event(event)
+
+    def flush(self, limit: int | None = None) -> list[dict[str, Any]]:
+        queue = self._queue
+        if queue is None:
+            return []
+        return queue.dump(limit=limit)
+
+
+telemetry_collector = TelemetryCollector()
+
+__all__ = [
+    'TelemetryCollector',
+    'TelemetryDirection',
+    'TelemetryEvent',
+    'TelemetryQueue',
+    'TelemetrySubsystem',
+    'telemetry_collector',
+]

--- a/rotkehlchen/tests/api/test_periodic.py
+++ b/rotkehlchen/tests/api/test_periodic.py
@@ -36,7 +36,6 @@ def test_query_periodic(rotkehlchen_api_server_with_exchanges: APIServer) -> Non
         periodic_url := api_url_for(rotkehlchen_api_server_with_exchanges, 'periodicdataresource'),
     )
     result = assert_proper_sync_response_with_result(response)
-    assert len(result) == 3
     assert result[DBCacheStatic.LAST_BALANCE_SAVE.value] >= start_ts
     assert 'failed_to_connect' not in result
     connected_nodes = result['connected_nodes']
@@ -45,6 +44,8 @@ def test_query_periodic(rotkehlchen_api_server_with_exchanges: APIServer) -> Non
         assert connected_nodes[evm_manager.node_inquirer.chain_name] == []
     # Non -1 value tests for these exist in test_history.py::test_query_history_timerange
     assert result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] == 0
+    telemetry_payload = result['telemetry']
+    assert isinstance(telemetry_payload, list)
 
     rotki.chains_aggregator.ethereum.node_inquirer.failed_to_connect_nodes.add('custom node')
     response = requests.get(periodic_url)

--- a/rotkehlchen/tests/unit/test_telemetry.py
+++ b/rotkehlchen/tests/unit/test_telemetry.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import requests
+
+from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.telemetry import TelemetryQueue, telemetry_collector
+from rotkehlchen.utils.network import retry_calls
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+def test_telemetry_queue_serialization() -> None:
+    queue = TelemetryQueue(maxlen=3)
+    telemetry_collector.set_queue(queue)
+    telemetry_collector.update_route('vpn-route')
+    try:
+        telemetry_collector.record_event(
+            subsystem='http',
+            direction='outbound',
+            endpoint='https://api.rotki.com/test',
+            latency_ms=42.5,
+            status_code=200,
+            success=True,
+            metadata={'info': 'sample'},
+        )
+        events = queue.dump()
+        assert len(events) == 1
+        event = events[0]
+        assert event['endpoint'] == 'https://api.rotki.com/test'
+        assert event['route'] == 'vpn-route'
+        assert event['metadata'] == {'info': 'sample'}
+    finally:
+        telemetry_collector.set_queue(None)
+        telemetry_collector.update_route('direct')
+
+
+def test_retry_calls_emits_telemetry() -> None:
+    queue = TelemetryQueue(maxlen=5)
+    telemetry_collector.set_queue(queue)
+    telemetry_collector.update_route('direct')
+
+    try:
+        def successful_call(url: str) -> _DummyResponse:
+            return _DummyResponse(200)
+
+        result = retry_calls(
+            times=1,
+            location='unit-test',
+            handle_429=False,
+            backoff_in_seconds=0,
+            method_name='success',
+            function=successful_call,
+            url='https://example.com/api',
+        )
+        assert result.status_code == 200
+        success_event = queue.dump()[-1]
+        assert success_event['endpoint'] == 'https://example.com/api'
+        assert success_event['success'] is True
+        assert success_event['status_code'] == 200
+
+        def failing_call(url: str) -> _DummyResponse:
+            raise requests.exceptions.Timeout('timeout')
+
+        try:
+            retry_calls(
+                times=1,
+                location='unit-test',
+                handle_429=False,
+                backoff_in_seconds=0,
+                method_name='failure',
+                function=failing_call,
+                url='https://example.com/api',
+            )
+        except RemoteError:
+            failure_event = queue.dump()[-1]
+            assert failure_event['success'] is False
+            assert failure_event['endpoint'] == 'https://example.com/api'
+            assert 'timeout' in failure_event['error']
+        else:  # pragma: no cover
+            assert False, 'RemoteError not raised'
+    finally:
+        telemetry_collector.set_queue(None)
+        telemetry_collector.update_route('direct')

--- a/rotkehlchen/utils/network.py
+++ b/rotkehlchen/utils/network.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections.abc import Callable
+from time import perf_counter
 from http import HTTPStatus
 from typing import Any, Literal, overload
 
@@ -13,6 +14,7 @@ from rotkehlchen.constants import GLOBAL_REQUESTS_TIMEOUT
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.telemetry import telemetry_collector
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -151,11 +153,24 @@ def retry_calls(
     - Raises RemoteError if there is something wrong with contacting the remote
     """
     tries = times
+    endpoint = str(kwargs.get('url') or method_name)
     while True:
+        start = perf_counter()
         try:
             result = function(**kwargs)
 
-            if handle_429 and result.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            status_code = getattr(result, 'status_code', None)
+            success = status_code is not None and status_code < HTTPStatus.BAD_REQUEST
+            telemetry_collector.record_event(
+                subsystem='http',
+                direction='outbound',
+                endpoint=endpoint,
+                latency_ms=(perf_counter() - start) * 1000,
+                status_code=status_code,
+                success=success,
+            )
+
+            if handle_429 and status_code == HTTPStatus.TOO_MANY_REQUESTS:
                 if tries == 0:
                     raise RemoteError(
                         f'{location} query for {method_name} failed after {times} tries',
@@ -172,6 +187,14 @@ def retry_calls(
             return result  # noqa: TRY300
 
         except requests.exceptions.RequestException as e:
+            telemetry_collector.record_event(
+                subsystem='http',
+                direction='outbound',
+                endpoint=endpoint,
+                latency_ms=(perf_counter() - start) * 1000,
+                success=False,
+                error=str(e),
+            )
             tries -= 1
             log.debug(
                 f'In retry_call for {location}-{method_name}. Got error {e!s} '


### PR DESCRIPTION
## Summary
- add a telemetry queue with VPN manager integration and instrument HTTP/WebSocket layers to emit events
- expose telemetry batches from the periodic API and surface them through a new Settings → Telemetry view with filtering
- cover telemetry aggregation, API schema, and UI parsing/rendering with new unit tests plus documentation for the dashboard

## Testing
- uv run python pytestgeventwrapper.py rotkehlchen/tests/unit/test_telemetry.py *(fails: uv could not download python-build-standalone because outbound network access is blocked)*
- pnpm --dir frontend/app test:unit -- --runInBand --filter telemetry *(fails: dependency installation forbidden by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7c9b9af8832ab4d40be2699b9108