### PR TITLE
Add VPN frontend tests and documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@ Contents
    api
    websockets
    telemetry-dashboard
+   vpn-routing
    changelog
    windows-build

--- a/docs/vpn-routing.rst
+++ b/docs/vpn-routing.rst
@@ -1,0 +1,43 @@
+VPN routing configuration
+=========================
+
+Rotki can coordinate outbound requests across multiple VPN tunnels. The VPN
+settings live under :menuselection:`Settings --> VPN Routing` and provide three
+cooperating tools:
+
+Profiles
+   Define how to reach each VPN endpoint. A profile stores the friendly name,
+   connection endpoint (for example a WireGuard URI), optional authentication
+   token, routing strategy (round robin or parallel), maximum simultaneous
+   tunnels, and whether the profile is currently enabled. The backend persists
+   these profiles in the user database so that reconnecting or restarting
+   rotki keeps the same configuration.
+
+Routing rules
+   Override the automatic dispatch for specific destinations. Rules let you
+   require, prefer, or avoid a profile when contacting a host. They also
+   support priorities so that the highest priority enabled rule wins for a
+   given destination.
+
+Status dashboard
+   Shows two perspectives: the real time runtime state collected from the VPN
+   lifecycle controller (active tunnels, last heartbeat, tunnel health) and the
+   persisted snapshot (profiles, routing rules, and tunnel metadata stored in
+   the database). Use the **Refresh snapshot** button if you changed data in
+   another client and want to pull the latest state without reloading the page.
+
+Typical workflow
+----------------
+
+1. Create one profile per VPN tunnel or gateway you can reach. Start with the
+   default ``round_robin`` strategy unless a gateway supports fan out (set
+   ``parallel`` when the endpoint can accept multiple simultaneous tunnels).
+2. If you need to steer traffic for a specific hostname, add a routing rule.
+   For example, set ``api.rotki.com`` to *require* a privacy focused tunnel
+   while keeping the default routing for everything else.
+3. Monitor the status dashboard. The runtime panel shows live tunnel changes
+   as rotki rotates connections. The snapshot section helps verify what is
+   stored on disk.
+
+The VPN manager also exposes its runtime state through the periodic session
+API. The frontend keeps the dashboard current as long as you remain logged in.

--- a/frontend/app/tests/unit/specs/components/settings/vpn/vpn-settings.spec.ts
+++ b/frontend/app/tests/unit/specs/components/settings/vpn/vpn-settings.spec.ts
@@ -1,0 +1,247 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, shallowMount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { ref, defineComponent, h } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import VpnProfileManager from '@/components/settings/vpn/VpnProfileManager.vue';
+import VpnRuleManager from '@/components/settings/vpn/VpnRuleManager.vue';
+import VpnSettings from '@/components/settings/vpn/VpnSettings.vue';
+import VpnStatusDashboard from '@/components/settings/vpn/VpnStatusDashboard.vue';
+import type {
+  VpnProfileRecord,
+  VpnRoutingRuleRecord,
+  VpnRuntimeStatus,
+  VpnSnapshot,
+  VpnTunnelStateRecord,
+} from '@/types/settings/vpn';
+
+const mockProfiles = ref<VpnProfileRecord[]>([]);
+const mockRules = ref<VpnRoutingRuleRecord[]>([]);
+const mockStatus = ref<VpnSnapshot | null>(null);
+const runtimeStatus = ref<VpnRuntimeStatus>({ profiles: [] });
+
+const loadMock = vi.fn();
+const refreshStatusMock = vi.fn();
+const createProfileMock = vi.fn();
+const updateProfileMock = vi.fn();
+const deleteProfileMock = vi.fn();
+const createRuleMock = vi.fn();
+const updateRuleMock = vi.fn();
+const deleteRuleMock = vi.fn();
+
+vi.mock('@/composables/settings/vpn/useVpnSettings', () => ({
+  useVpnSettings: () => ({
+    load: loadMock,
+    refreshStatus: refreshStatusMock,
+    profiles: mockProfiles,
+    routingRules: mockRules,
+    status: mockStatus,
+    createProfile: createProfileMock,
+    updateProfile: updateProfileMock,
+    deleteProfile: deleteProfileMock,
+    createRule: createRuleMock,
+    updateRule: updateRuleMock,
+    deleteRule: deleteRuleMock,
+  }),
+}));
+
+vi.mock('@/composables/settings/vpn/useVpnRuntimeStatus', () => ({
+  useVpnRuntimeStatus: () => ({ runtimeStatus }),
+}));
+
+const SimpleTableStub = defineComponent({
+  setup(_, { slots }) {
+    return () => h('table', [h('tbody', slots.default?.())]);
+  },
+});
+
+const RuiButtonStub = defineComponent({
+  emits: ['click'],
+  setup(_, { emit, slots }) {
+    return () => h('button', { onClick: () => emit('click') }, slots.default?.());
+  },
+});
+
+const RuiTextFieldStub = defineComponent({
+  props: { modelValue: { type: [String, Number], default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('input', {
+      value: props.modelValue,
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value),
+    });
+  },
+});
+
+const RuiCheckboxStub = defineComponent({
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('input', {
+      type: 'checkbox',
+      checked: props.modelValue,
+      onChange: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).checked),
+    });
+  },
+});
+
+const SlotStub = defineComponent({
+  setup(_, { slots }) {
+    return () => slots.default?.();
+  },
+});
+
+describe('VPN settings components', () => {
+  const pinia = createPinia();
+  const stubs = {
+    SimpleTable: SimpleTableStub,
+    RuiButton: RuiButtonStub,
+    RuiTextField: RuiTextFieldStub,
+    RuiCheckbox: RuiCheckboxStub,
+    RuiBadge: SlotStub,
+    RowActions: SlotStub,
+    BigDialog: SlotStub,
+  };
+
+  beforeEach(() => {
+    document.body.dataset.app = 'true';
+    mockProfiles.value = [];
+    mockRules.value = [];
+    mockStatus.value = null;
+    runtimeStatus.value = { profiles: [] };
+    loadMock.mockReset();
+    refreshStatusMock.mockReset();
+    createProfileMock.mockReset();
+    updateProfileMock.mockReset();
+    deleteProfileMock.mockReset();
+    createRuleMock.mockReset();
+    updateRuleMock.mockReset();
+    deleteRuleMock.mockReset();
+  });
+
+  it('invokes load when mounting VpnSettings', async () => {
+    shallowMount(VpnSettings, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs: {
+          VpnStatusDashboard: true,
+          VpnProfileManager: true,
+          VpnRuleManager: true,
+        },
+      },
+    });
+
+    expect(loadMock).toHaveBeenCalledOnce();
+  });
+
+  it('renders runtime and snapshot status in VpnStatusDashboard', () => {
+    const tunnels: VpnTunnelStateRecord[] = [
+      {
+        identifier: 5,
+        profile_id: 1,
+        endpoint: 'wireguard://primary#0',
+        state: 'active',
+        last_heartbeat: 123,
+        failure_count: 0,
+        rotation_cursor: 0,
+      },
+    ];
+
+    runtimeStatus.value = {
+      profiles: [
+        {
+          profile: {
+            identifier: 1,
+            name: 'primary',
+            endpoint: 'wireguard://primary',
+            auth_token: null,
+            routing_strategy: 'parallel',
+            max_parallel: 1,
+            enabled: true,
+          },
+          tunnels,
+        },
+      ],
+    } satisfies VpnRuntimeStatus;
+
+    mockStatus.value = {
+      profiles: runtimeStatus.value.profiles.map(entry => entry.profile),
+      rules: [
+        {
+          identifier: 10,
+          profile_id: 1,
+          destination: 'api.rotki.com',
+          action: 'prefer',
+          priority: 5,
+          enabled: true,
+        },
+      ],
+      tunnels,
+    } satisfies VpnSnapshot;
+
+    const wrapper = mount(VpnStatusDashboard, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs,
+      },
+    });
+
+    expect(wrapper.text()).toContain('primary');
+    expect(wrapper.text()).toContain('wireguard://primary#0');
+    expect(wrapper.text()).toContain('api.rotki.com');
+
+    wrapper.findComponent(RuiButtonStub).trigger('click');
+    expect(refreshStatusMock).toHaveBeenCalledOnce();
+  });
+
+  it('lists profiles in VpnProfileManager', () => {
+    mockProfiles.value = [
+      {
+        identifier: 1,
+        name: 'primary',
+        endpoint: 'wireguard://primary',
+        auth_token: null,
+        routing_strategy: 'round_robin',
+        max_parallel: 1,
+        enabled: true,
+      },
+    ];
+
+    const wrapper = mount(VpnProfileManager, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs,
+      },
+    });
+
+    expect(wrapper.text()).toContain('primary');
+    expect(wrapper.text()).toContain('wireguard://primary');
+  });
+
+  it('lists routing rules in VpnRuleManager', () => {
+    mockRules.value = [
+      {
+        identifier: 3,
+        profile_id: 1,
+        destination: 'rpc.rotki.com',
+        action: 'require',
+        priority: 2,
+        enabled: true,
+      },
+    ];
+
+    const wrapper = mount(VpnRuleManager, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs,
+      },
+    });
+
+    expect(wrapper.text()).toContain('rpc.rotki.com');
+    expect(wrapper.text()).toContain('require');
+  });
+});

--- a/frontend/app/tests/unit/specs/store/settings/vpn.spec.ts
+++ b/frontend/app/tests/unit/specs/store/settings/vpn.spec.ts
@@ -1,0 +1,178 @@
+import { createPinia, type Pinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVpnSettingsStore } from '@/store/settings/vpn';
+import type {
+  VpnProfileRecord,
+  VpnRoutingRuleRecord,
+  VpnSnapshot,
+} from '@/types/settings/vpn';
+
+const apiMock = {
+  fetchProfiles: vi.fn<[], Promise<VpnProfileRecord[]>>(),
+  createProfile: vi.fn<[Omit<VpnProfileRecord, 'identifier'>], Promise<VpnProfileRecord>>(),
+  updateProfile: vi.fn<[VpnProfileRecord], Promise<VpnProfileRecord>>(),
+  deleteProfile: vi.fn<[number], Promise<boolean>>(),
+  fetchRules: vi.fn<[], Promise<VpnRoutingRuleRecord[]>>(),
+  createRule: vi.fn<[Omit<VpnRoutingRuleRecord, 'identifier'>], Promise<VpnRoutingRuleRecord>>(),
+  updateRule: vi.fn<[VpnRoutingRuleRecord], Promise<VpnRoutingRuleRecord>>(),
+  deleteRule: vi.fn<[number], Promise<boolean>>(),
+  fetchStatus: vi.fn<[], Promise<VpnSnapshot>>(),
+};
+
+vi.mock('@/composables/api/settings/vpn-api', () => ({
+  useVpnSettingsApi: () => apiMock,
+}));
+
+describe('settings/vpn store', () => {
+  let pinia: Pinia;
+
+  const sampleProfile: VpnProfileRecord = {
+    identifier: 1,
+    name: 'primary',
+    endpoint: 'wireguard://primary',
+    auth_token: null,
+    routing_strategy: 'round_robin',
+    max_parallel: 1,
+    enabled: true,
+  };
+
+  const updatedProfile: VpnProfileRecord = {
+    ...sampleProfile,
+    name: 'primary-updated',
+  };
+
+  const sampleRule: VpnRoutingRuleRecord = {
+    identifier: 11,
+    profile_id: 1,
+    destination: 'api.rotki.com',
+    action: 'prefer',
+    priority: 5,
+    enabled: true,
+  };
+
+  const snapshot: VpnSnapshot = {
+    profiles: [sampleProfile],
+    rules: [sampleRule],
+    tunnels: [],
+  };
+
+  beforeEach(() => {
+    pinia = createPinia();
+    Object.values(apiMock).forEach(mock => mock.mockReset());
+    apiMock.fetchProfiles.mockResolvedValue([sampleProfile]);
+    apiMock.fetchRules.mockResolvedValue([sampleRule]);
+    apiMock.fetchStatus.mockResolvedValue(snapshot);
+  });
+
+  it('loads VPN data from the API', async () => {
+    const store = useVpnSettingsStore(pinia);
+    await store.load();
+
+    expect(apiMock.fetchProfiles).toHaveBeenCalledOnce();
+    expect(apiMock.fetchRules).toHaveBeenCalledOnce();
+    expect(apiMock.fetchStatus).toHaveBeenCalledOnce();
+    expect(store.profiles).toEqual([sampleProfile]);
+    expect(store.routingRules).toEqual([sampleRule]);
+    expect(store.status).toEqual(snapshot);
+  });
+
+  it('adds, edits, and removes profiles', async () => {
+    const store = useVpnSettingsStore(pinia);
+    await store.load();
+
+    apiMock.createProfile.mockResolvedValue({
+      ...sampleProfile,
+      identifier: 2,
+      name: 'backup',
+    });
+    const created = await store.addProfile({
+      identifier: null,
+      name: 'backup',
+      endpoint: 'wireguard://backup',
+      auth_token: null,
+      routing_strategy: 'round_robin',
+      max_parallel: 1,
+      enabled: true,
+    });
+
+    expect(apiMock.createProfile).toHaveBeenCalledOnce();
+    expect(created.name).toBe('backup');
+    expect(store.profiles).toHaveLength(2);
+
+    apiMock.updateProfile.mockResolvedValue(updatedProfile);
+    const result = await store.editProfile(updatedProfile);
+
+    expect(apiMock.updateProfile).toHaveBeenCalledOnce();
+    expect(result.name).toBe('primary-updated');
+    expect(store.profiles?.find(profile => profile.identifier === 1)?.name).toBe('primary-updated');
+
+    apiMock.deleteProfile.mockResolvedValue(true);
+    const removed = await store.removeProfile(1);
+
+    expect(apiMock.deleteProfile).toHaveBeenCalledWith(1);
+    expect(removed).toBe(true);
+    expect(store.profiles?.some(profile => profile.identifier === 1)).toBe(false);
+  });
+
+  it('adds, edits, and removes routing rules', async () => {
+    const store = useVpnSettingsStore(pinia);
+    await store.load();
+
+    apiMock.createRule.mockResolvedValue({
+      identifier: 22,
+      profile_id: 1,
+      destination: 'ws.rotki.com',
+      action: 'require',
+      priority: 10,
+      enabled: true,
+    });
+    const createdRule = await store.addRule({
+      identifier: null,
+      profile_id: 1,
+      destination: 'ws.rotki.com',
+      action: 'require',
+      priority: 10,
+      enabled: true,
+    });
+
+    expect(apiMock.createRule).toHaveBeenCalledOnce();
+    expect(createdRule.destination).toBe('ws.rotki.com');
+    expect(store.routingRules).toHaveLength(2);
+
+    const updatedRule: VpnRoutingRuleRecord = {
+      ...sampleRule,
+      destination: 'api.rotki.io',
+    };
+    apiMock.updateRule.mockResolvedValue(updatedRule);
+    const saved = await store.editRule(updatedRule);
+
+    expect(apiMock.updateRule).toHaveBeenCalledOnce();
+    expect(saved.destination).toBe('api.rotki.io');
+    expect(store.routingRules?.find(rule => rule.identifier === sampleRule.identifier)?.destination)
+      .toBe('api.rotki.io');
+
+    apiMock.deleteRule.mockResolvedValue(true);
+    const deleted = await store.removeRule(sampleRule.identifier ?? 0);
+
+    expect(apiMock.deleteRule).toHaveBeenCalledWith(sampleRule.identifier);
+    expect(deleted).toBe(true);
+    expect(store.routingRules?.some(rule => rule.identifier === sampleRule.identifier)).toBe(false);
+  });
+
+  it('refreshes cached status', async () => {
+    const store = useVpnSettingsStore(pinia);
+    await store.load();
+
+    const updatedSnapshot: VpnSnapshot = {
+      profiles: [],
+      rules: [],
+      tunnels: [],
+    };
+    apiMock.fetchStatus.mockResolvedValue(updatedSnapshot);
+
+    await store.refreshStatus();
+
+    expect(apiMock.fetchStatus).toHaveBeenCalledTimes(2);
+    expect(store.status).toEqual(updatedSnapshot);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest coverage for the VPN settings store and UI components
- document how to configure multi-profile VPN routing and link it from the docs index

## Testing
- pnpm exec vitest run tests/unit/specs/store/settings/vpn.spec.ts tests/unit/specs/components/settings/vpn/vpn-settings.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68eb109c31a4832a82a935ba4523c53f