### PR TITLE
Add missing VPN modules for tests

### DIFF
--- a/frontend/app/src/components/settings/vpn/VpnProfileManager.vue
+++ b/frontend/app/src/components/settings/vpn/VpnProfileManager.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import SimpleTable from '@/components/common/SimpleTable.vue';
+import { useVpnSettings } from '@/composables/settings/vpn/useVpnSettings';
+
+const { profiles } = useVpnSettings();
+const profileList = computed(() => profiles.value);
+</script>
+
+<template>
+  <section class="space-y-3">
+    <header>
+      <h2 class="text-lg font-semibold">
+        VPN profiles
+      </h2>
+    </header>
+    <SimpleTable v-if="profileList.length">
+      <template #default>
+        <tr v-for="profile in profileList" :key="profile.identifier ?? profile.name">
+          <td class="font-semibold">
+            {{ profile.name }}
+          </td>
+          <td>{{ profile.endpoint }}</td>
+        </tr>
+      </template>
+    </SimpleTable>
+    <p v-else class="text-sm text-rui-text-secondary">
+      No VPN profiles configured
+    </p>
+  </section>
+</template>

--- a/frontend/app/src/components/settings/vpn/VpnRuleManager.vue
+++ b/frontend/app/src/components/settings/vpn/VpnRuleManager.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import SimpleTable from '@/components/common/SimpleTable.vue';
+import { useVpnSettings } from '@/composables/settings/vpn/useVpnSettings';
+
+const { routingRules } = useVpnSettings();
+const rules = computed(() => routingRules.value);
+</script>
+
+<template>
+  <section class="space-y-3">
+    <header>
+      <h2 class="text-lg font-semibold">
+        Routing rules
+      </h2>
+    </header>
+    <SimpleTable v-if="rules.length">
+      <template #default>
+        <tr v-for="rule in rules" :key="rule.identifier ?? rule.destination">
+          <td>{{ rule.destination }}</td>
+          <td class="capitalize">{{ rule.action }}</td>
+        </tr>
+      </template>
+    </SimpleTable>
+    <p v-else class="text-sm text-rui-text-secondary">
+      No routing rules configured
+    </p>
+  </section>
+</template>

--- a/frontend/app/src/components/settings/vpn/VpnSettings.vue
+++ b/frontend/app/src/components/settings/vpn/VpnSettings.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import VpnProfileManager from '@/components/settings/vpn/VpnProfileManager.vue';
+import VpnRuleManager from '@/components/settings/vpn/VpnRuleManager.vue';
+import VpnStatusDashboard from '@/components/settings/vpn/VpnStatusDashboard.vue';
+import { useVpnSettings } from '@/composables/settings/vpn/useVpnSettings';
+
+const { load } = useVpnSettings();
+
+onMounted(() => {
+  void load();
+});
+</script>
+
+<template>
+  <div class="space-y-6">
+    <VpnStatusDashboard />
+    <VpnProfileManager />
+    <VpnRuleManager />
+  </div>
+</template>

--- a/frontend/app/src/components/settings/vpn/VpnStatusDashboard.vue
+++ b/frontend/app/src/components/settings/vpn/VpnStatusDashboard.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import SimpleTable from '@/components/common/SimpleTable.vue';
+import { useVpnRuntimeStatus } from '@/composables/settings/vpn/useVpnRuntimeStatus';
+import { useVpnSettings } from '@/composables/settings/vpn/useVpnSettings';
+
+const { runtimeStatus } = useVpnRuntimeStatus();
+const { status, refreshStatus } = useVpnSettings();
+
+const runtimeProfiles = computed(() => runtimeStatus.value?.profiles ?? []);
+const snapshotRules = computed(() => status.value?.rules ?? []);
+const snapshotTunnels = computed(() => status.value?.tunnels ?? []);
+const snapshotProfiles = computed(() => status.value?.profiles ?? []);
+</script>
+
+<template>
+  <section class="space-y-4">
+    <header class="flex items-center justify-between">
+      <h2 class="text-lg font-semibold">
+        VPN status
+      </h2>
+      <RuiButton @click="refreshStatus()">
+        Refresh
+      </RuiButton>
+    </header>
+
+    <div class="space-y-2">
+      <h3 class="font-medium">Runtime</h3>
+      <SimpleTable v-if="runtimeProfiles.length">
+        <template #default>
+          <tr v-for="item in runtimeProfiles" :key="item.profile.identifier">
+            <td class="font-semibold">
+              {{ item.profile.name }}
+            </td>
+            <td>
+              <ul class="space-y-1">
+                <li v-for="tunnel in item.tunnels" :key="tunnel.identifier">
+                  {{ tunnel.endpoint }}
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </template>
+      </SimpleTable>
+      <p v-else class="text-rui-text-secondary text-sm">
+        No active VPN tunnels
+      </p>
+    </div>
+
+    <div class="space-y-2">
+      <h3 class="font-medium">Snapshot</h3>
+      <div v-if="snapshotProfiles.length" class="space-y-1">
+        <h4 class="text-sm font-semibold text-rui-text-secondary">
+          Profiles
+        </h4>
+        <ul class="space-y-1">
+          <li v-for="profile in snapshotProfiles" :key="profile.identifier">
+            {{ profile.name }} - {{ profile.endpoint }}
+          </li>
+        </ul>
+      </div>
+      <div v-if="snapshotRules.length" class="space-y-1">
+        <h4 class="text-sm font-semibold text-rui-text-secondary">
+          Routing rules
+        </h4>
+        <SimpleTable>
+          <template #default>
+            <tr v-for="rule in snapshotRules" :key="rule.identifier">
+              <td>{{ rule.destination }}</td>
+              <td>{{ rule.action }}</td>
+            </tr>
+          </template>
+        </SimpleTable>
+      </div>
+      <div v-if="snapshotTunnels.length" class="space-y-1">
+        <h4 class="text-sm font-semibold text-rui-text-secondary">
+          Tunnels
+        </h4>
+        <ul class="space-y-1">
+          <li v-for="tunnel in snapshotTunnels" :key="tunnel.identifier">
+            {{ tunnel.endpoint }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>

--- a/frontend/app/src/composables/api/settings/vpn-api.ts
+++ b/frontend/app/src/composables/api/settings/vpn-api.ts
@@ -1,0 +1,119 @@
+import type { ActionResult } from '@rotki/common';
+import { api } from '@/services/rotkehlchen-api';
+import { handleResponse, validStatus } from '@/services/utils';
+import type {
+  VpnProfileDraft,
+  VpnProfileRecord,
+  VpnRoutingRuleDraft,
+  VpnRoutingRuleRecord,
+  VpnSnapshot,
+} from '@/types/settings/vpn';
+import { snakeCaseTransformer } from '@/services/axios-transformers';
+
+interface UseVpnSettingsApiReturn {
+  fetchProfiles: () => Promise<VpnProfileRecord[]>;
+  createProfile: (profile: VpnProfileDraft) => Promise<VpnProfileRecord>;
+  updateProfile: (profile: VpnProfileRecord) => Promise<VpnProfileRecord>;
+  deleteProfile: (identifier: number) => Promise<boolean>;
+  fetchRules: () => Promise<VpnRoutingRuleRecord[]>;
+  createRule: (rule: VpnRoutingRuleDraft) => Promise<VpnRoutingRuleRecord>;
+  updateRule: (rule: VpnRoutingRuleRecord) => Promise<VpnRoutingRuleRecord>;
+  deleteRule: (identifier: number) => Promise<boolean>;
+  fetchStatus: () => Promise<VpnSnapshot>;
+}
+
+export function useVpnSettingsApi(): UseVpnSettingsApiReturn {
+  const fetchProfiles = async (): Promise<VpnProfileRecord[]> => {
+    const response = await api.instance.get<ActionResult<VpnProfileRecord[]>>('/settings/vpn/profiles', {
+      validateStatus: validStatus,
+    });
+
+    return handleResponse(response);
+  };
+
+  const createProfile = async (profile: VpnProfileDraft): Promise<VpnProfileRecord> => {
+    const response = await api.instance.put<ActionResult<VpnProfileRecord>>(
+      '/settings/vpn/profiles',
+      snakeCaseTransformer(profile),
+      { validateStatus: validStatus },
+    );
+
+    return handleResponse(response);
+  };
+
+  const updateProfile = async (profile: VpnProfileRecord): Promise<VpnProfileRecord> => {
+    const response = await api.instance.patch<ActionResult<VpnProfileRecord>>(
+      '/settings/vpn/profiles',
+      snakeCaseTransformer(profile),
+      { validateStatus: validStatus },
+    );
+
+    return handleResponse(response);
+  };
+
+  const deleteProfile = async (identifier: number): Promise<boolean> => {
+    const response = await api.instance.delete<ActionResult<boolean>>('/settings/vpn/profiles', {
+      data: snakeCaseTransformer({ identifier }),
+      validateStatus: validStatus,
+    });
+
+    return handleResponse(response);
+  };
+
+  const fetchRules = async (): Promise<VpnRoutingRuleRecord[]> => {
+    const response = await api.instance.get<ActionResult<VpnRoutingRuleRecord[]>>('/settings/vpn/rules', {
+      validateStatus: validStatus,
+    });
+
+    return handleResponse(response);
+  };
+
+  const createRule = async (rule: VpnRoutingRuleDraft): Promise<VpnRoutingRuleRecord> => {
+    const response = await api.instance.put<ActionResult<VpnRoutingRuleRecord>>(
+      '/settings/vpn/rules',
+      snakeCaseTransformer(rule),
+      { validateStatus: validStatus },
+    );
+
+    return handleResponse(response);
+  };
+
+  const updateRule = async (rule: VpnRoutingRuleRecord): Promise<VpnRoutingRuleRecord> => {
+    const response = await api.instance.patch<ActionResult<VpnRoutingRuleRecord>>(
+      '/settings/vpn/rules',
+      snakeCaseTransformer(rule),
+      { validateStatus: validStatus },
+    );
+
+    return handleResponse(response);
+  };
+
+  const deleteRule = async (identifier: number): Promise<boolean> => {
+    const response = await api.instance.delete<ActionResult<boolean>>('/settings/vpn/rules', {
+      data: snakeCaseTransformer({ identifier }),
+      validateStatus: validStatus,
+    });
+
+    return handleResponse(response);
+  };
+
+  const fetchStatus = async (): Promise<VpnSnapshot> => {
+    const response = await api.instance.get<ActionResult<VpnSnapshot>>('/settings/vpn/status', {
+      validateStatus: validStatus,
+    });
+
+    return handleResponse(response);
+  };
+
+  return {
+    fetchProfiles,
+    createProfile,
+    updateProfile,
+    deleteProfile,
+    fetchRules,
+    createRule,
+    updateRule,
+    deleteRule,
+    fetchStatus,
+  };
+}

--- a/frontend/app/src/composables/settings/vpn/useVpnRuntimeStatus.ts
+++ b/frontend/app/src/composables/settings/vpn/useVpnRuntimeStatus.ts
@@ -1,0 +1,8 @@
+import { ref } from 'vue';
+import type { VpnRuntimeStatus } from '@/types/settings/vpn';
+
+const runtimeStatus = ref<VpnRuntimeStatus>({ profiles: [] });
+
+export function useVpnRuntimeStatus() {
+  return { runtimeStatus };
+}

--- a/frontend/app/src/composables/settings/vpn/useVpnSettings.ts
+++ b/frontend/app/src/composables/settings/vpn/useVpnSettings.ts
@@ -1,0 +1,22 @@
+import { storeToRefs } from 'pinia';
+import { useVpnSettingsStore } from '@/store/settings/vpn';
+
+export function useVpnSettings() {
+  const store = useVpnSettingsStore();
+  const { profiles, routingRules, status, loading } = storeToRefs(store);
+
+  return {
+    profiles,
+    routingRules,
+    status,
+    loading,
+    load: store.load,
+    refreshStatus: store.refreshStatus,
+    createProfile: store.addProfile,
+    updateProfile: store.editProfile,
+    deleteProfile: store.removeProfile,
+    createRule: store.addRule,
+    updateRule: store.editRule,
+    deleteRule: store.removeRule,
+  };
+}

--- a/frontend/app/src/store/settings/vpn.ts
+++ b/frontend/app/src/store/settings/vpn.ts
@@ -1,0 +1,106 @@
+import { acceptHMRUpdate, defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useVpnSettingsApi } from '@/composables/api/settings/vpn-api';
+import type {
+  VpnProfileDraft,
+  VpnProfileRecord,
+  VpnRoutingRuleDraft,
+  VpnRoutingRuleRecord,
+  VpnSnapshot,
+} from '@/types/settings/vpn';
+
+export const useVpnSettingsStore = defineStore('settings/vpn', () => {
+  const loading = ref(false);
+  const profiles = ref<VpnProfileRecord[]>([]);
+  const routingRules = ref<VpnRoutingRuleRecord[]>([]);
+  const status = ref<VpnSnapshot | null>(null);
+
+  const api = useVpnSettingsApi();
+
+  const load = async (): Promise<void> => {
+    loading.value = true;
+    try {
+      const [fetchedProfiles, fetchedRules, snapshot] = await Promise.all([
+        api.fetchProfiles(),
+        api.fetchRules(),
+        api.fetchStatus(),
+      ]);
+      profiles.value = fetchedProfiles;
+      routingRules.value = fetchedRules;
+      status.value = snapshot;
+    }
+    finally {
+      loading.value = false;
+    }
+  };
+
+  const refreshStatus = async (): Promise<VpnSnapshot | null> => {
+    try {
+      const snapshot = await api.fetchStatus();
+      status.value = snapshot;
+      return snapshot;
+    }
+    catch (error) {
+      console.error(error);
+      return null;
+    }
+  };
+
+  const addProfile = async (profile: VpnProfileDraft): Promise<VpnProfileRecord> => {
+    const result = await api.createProfile(profile);
+    profiles.value = [...profiles.value, result];
+    return result;
+  };
+
+  const editProfile = async (profile: VpnProfileRecord): Promise<VpnProfileRecord> => {
+    const result = await api.updateProfile(profile);
+    profiles.value = profiles.value.map(existing => (existing.identifier === result.identifier ? result : existing));
+    return result;
+  };
+
+  const removeProfile = async (identifier: number): Promise<boolean> => {
+    const success = await api.deleteProfile(identifier);
+    if (success)
+      profiles.value = profiles.value.filter(profile => profile.identifier !== identifier);
+
+    return success;
+  };
+
+  const addRule = async (rule: VpnRoutingRuleDraft): Promise<VpnRoutingRuleRecord> => {
+    const result = await api.createRule(rule);
+    routingRules.value = [...routingRules.value, result];
+    return result;
+  };
+
+  const editRule = async (rule: VpnRoutingRuleRecord): Promise<VpnRoutingRuleRecord> => {
+    const result = await api.updateRule(rule);
+    routingRules.value = routingRules.value.map(existing => (existing.identifier === result.identifier ? result : existing));
+    return result;
+  };
+
+  const removeRule = async (identifier: number): Promise<boolean> => {
+    const success = await api.deleteRule(identifier);
+    if (success)
+      routingRules.value = routingRules.value.filter(rule => rule.identifier !== identifier);
+
+    return success;
+  };
+
+  return {
+    loading,
+    profiles,
+    routingRules,
+    status,
+    addProfile,
+    addRule,
+    editProfile,
+    editRule,
+    load,
+    refreshStatus,
+    removeProfile,
+    removeRule,
+  };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useVpnSettingsStore, import.meta.hot));

--- a/frontend/app/src/types/settings/vpn.ts
+++ b/frontend/app/src/types/settings/vpn.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+export const vpnProfileRecordValidator = z.object({
+  identifier: z.number().nullable(),
+  name: z.string(),
+  endpoint: z.string(),
+  auth_token: z.string().nullable(),
+  routing_strategy: z.enum(['round_robin', 'parallel']),
+  max_parallel: z.number(),
+  enabled: z.boolean(),
+});
+
+export const vpnProfileRecordWithIdValidator = vpnProfileRecordValidator.extend({
+  identifier: z.number(),
+});
+
+export type VpnProfileRecord = z.infer<typeof vpnProfileRecordWithIdValidator>;
+export type VpnProfileDraft = z.infer<typeof vpnProfileRecordValidator>;
+
+export const vpnRoutingRuleRecordValidator = z.object({
+  identifier: z.number().nullable(),
+  profile_id: z.number(),
+  destination: z.string(),
+  action: z.enum(['prefer', 'require', 'avoid']),
+  priority: z.number(),
+  enabled: z.boolean(),
+});
+
+export const vpnRoutingRuleRecordWithIdValidator = vpnRoutingRuleRecordValidator.extend({
+  identifier: z.number(),
+});
+
+export type VpnRoutingRuleRecord = z.infer<typeof vpnRoutingRuleRecordWithIdValidator>;
+export type VpnRoutingRuleDraft = z.infer<typeof vpnRoutingRuleRecordValidator>;
+
+export const vpnTunnelStateRecordValidator = z.object({
+  identifier: z.number(),
+  profile_id: z.number(),
+  endpoint: z.string(),
+  state: z.string(),
+  last_heartbeat: z.number().nullable(),
+  failure_count: z.number(),
+  rotation_cursor: z.number().nullable(),
+});
+
+export type VpnTunnelStateRecord = z.infer<typeof vpnTunnelStateRecordValidator>;
+
+export const vpnSnapshotValidator = z.object({
+  profiles: z.array(vpnProfileRecordWithIdValidator),
+  rules: z.array(vpnRoutingRuleRecordWithIdValidator),
+  tunnels: z.array(vpnTunnelStateRecordValidator),
+});
+
+export type VpnSnapshot = z.infer<typeof vpnSnapshotValidator>;
+
+export const vpnRuntimeStatusValidator = z.object({
+  profiles: z.array(
+    z.object({
+      profile: vpnProfileRecordWithIdValidator,
+      tunnels: z.array(vpnTunnelStateRecordValidator),
+    }),
+  ),
+});
+
+export type VpnRuntimeStatus = z.infer<typeof vpnRuntimeStatusValidator>;
+
+export interface UseVpnSettingsState {
+  readonly profiles: VpnProfileRecord[];
+  readonly routingRules: VpnRoutingRuleRecord[];
+  readonly status: VpnSnapshot | null;
+}


### PR DESCRIPTION
## Summary
- add VPN settings store, API wrapper, and supporting types
- add composables and UI components so the VPN tests can mount and render

## Testing
- pnpm exec vitest --config app/vitest.config.ts run tests/unit/specs/store/settings/vpn.spec.ts tests/unit/specs/components/settings/vpn/vpn-settings.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68eba453d658832a80e051388c28609b