### PR TITLE
Document Codex setup protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,21 @@ Rotki is a privacy-focused crypto portfolio management and tax reporting applica
 - **Vue.js/TypeScript frontend** (Electron desktop app + web interface)
 - **Rust service** (Colibri - performance-critical components)
 
+## ChatGPT Codex Environment Setup Protocol
+
+- The ChatGPT Codex environment bootstrap script now lives in `CHATGPT_CODEX_ENV.md` as a fenced code block. Copy it into the
+  environment's **Setup script** field instead of running it from the repository.
+- When a user asks for script updates:
+  1. Draft the new script and execute it inside the active workspace to confirm it prepares the environment successfully.
+  2. Update the script block in `CHATGPT_CODEX_ENV.md` once the smoke test passes.
+  3. Share a copy-ready link in the PR (for example
+     `https://raw.githubusercontent.com/rotki/rotki/<branch>/CHATGPT_CODEX_ENV.md?plain=1`) so maintainers can grab the script
+     without Markdown fencing.
+  4. Highlight in the PR message that maintainers must paste the script into the Codex settings and re-run the environment's
+     interactive terminal before merging.
+- The maintainer checklist for this flow is documented in `CHATGPT_CODEX_ENV.md`. Coordinate with repository owners if extra
+  automation (such as a GitHub Action that surfaces the script contents) is required.
+
 ## Development Commands
 
 ### Prerequisites

--- a/CHATGPT_CODEX_ENV.md
+++ b/CHATGPT_CODEX_ENV.md
@@ -1,3 +1,12 @@
+# ChatGPT Codex Environment Setup
+
+This document centralizes the resources required to run rotki in the ChatGPT Codex managed environment. The setup script lives here so it can be copied into the **Setup script** field of the environment settings. The script is **never** executed directly from the repository checkout.
+
+## Setup Script v8
+
+> Copy the following block verbatim into the ChatGPT Codex Rotki environment's **Setup script** field. It is intended for that UI only.
+
+```bash
 #!/usr/bin/env bash
 #
 # setup.v8.sh
@@ -158,3 +167,24 @@ else
 fi
 
 echo "[setup v8] ✅ Done! Environment is ready. ✨"
+```
+
+## Update Protocol for Assistants
+
+When a user asks for changes to the setup script:
+
+1. Draft the updated script and run it inside the active workspace to ensure it finishes successfully and prepares the ChatGPT Codex environment as expected. Capture logs for review.
+2. Once the smoke test is green, replace the script block above with the new version.
+3. In the pull request summary or comments, include a copy-ready link to the raw Markdown file. Use `https://raw.githubusercontent.com/rotki/rotki/<branch>/CHATGPT_CODEX_ENV.md?plain=1` (substitute `<branch>` with the PR branch name) so maintainers can copy the script without Markdown delimiters.
+4. Call out in the PR description that the maintainer must paste the script into the ChatGPT Codex environment settings and re-run the built-in interactive terminal to verify it.
+
+## Maintainer Checklist
+
+Maintainers should follow the steps below after receiving a script update:
+
+1. Open the raw link shared in the PR, copy the script, and paste it into the ChatGPT Codex Rotki environment's **Setup script** field.
+2. Connect the environment's interactive terminal to execute the script and ensure it completes successfully.
+3. Save the updated script in the ChatGPT Codex environment settings and confirm it persisted by refreshing the settings page.
+4. Merge the pull request only after the manual verification succeeds.
+
+If additional automation (such as a GitHub Action that surfaces the script content) is needed, coordinate with the repository maintainers before merging.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,21 @@ Rotki is a privacy-focused crypto portfolio management and tax reporting applica
 - **Vue.js/TypeScript frontend** (Electron desktop app + web interface)
 - **Rust service** (Colibri - performance-critical components)
 
+## ChatGPT Codex Environment Setup Protocol
+
+- The ChatGPT Codex environment bootstrap script now lives in `CHATGPT_CODEX_ENV.md` as a fenced code block. Copy it into the
+  environment's **Setup script** field instead of running it from the repository.
+- When a user asks for script updates:
+  1. Draft the new script and execute it inside the active workspace to confirm it prepares the environment successfully.
+  2. Update the script block in `CHATGPT_CODEX_ENV.md` once the smoke test passes.
+  3. Share a copy-ready link in the PR (for example
+     `https://raw.githubusercontent.com/rotki/rotki/<branch>/CHATGPT_CODEX_ENV.md?plain=1`) so maintainers can grab the script
+     without Markdown fencing.
+  4. Highlight in the PR message that maintainers must paste the script into the Codex settings and re-run the environment's
+     interactive terminal before merging.
+- The maintainer checklist for this flow is documented in `CHATGPT_CODEX_ENV.md`. Coordinate with repository owners if extra
+  automation (such as a GitHub Action that surfaces the script contents) is required.
+
 ## Development Commands
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [🔧 Requirements](#requirements)
 - [🚀 Installation](#installation)
 - [📘 Usage](#usage)
+- [🤖 ChatGPT Codex Environment Setup](#chatgpt-codex-environment-setup)
 - [📜 Changelog](#changelog)
 - [🤝 Contribute](#contribute)
 - [📢 Get in Touch](#get-in-touch)
@@ -109,8 +110,19 @@ For **detailed setup and usage guides**, visit our [documentation](https://docs.
 - Configure settings & import your addresses.
 - Start managing and analyzing your portfolio! 🚀
 
-🛠 **Working on the codebase?**  
+🛠 **Working on the codebase?**
 Local setup helpers live in `PIPELINE.md`, and long-lived-branch/rebase guidance is in `PIPELINE_FOR_GIT.md`.
+
+<div id="chatgpt-codex-environment-setup"></div>
+
+## 🤖 **ChatGPT Codex Environment Setup**
+
+The ChatGPT Codex managed workspace relies on the script documented in [CHATGPT_CODEX_ENV.md](./CHATGPT_CODEX_ENV.md). Copy the
+script block from that file into the environment's **Setup script** field—do not run it directly inside the repository. The doc
+describes the verification workflow for future updates, including the smoke test requirement and the need to share a copy-ready
+raw link so maintainers can re-test it before merging changes.
+
+Maintainers should follow the checklist in `CHATGPT_CODEX_ENV.md` to validate new scripts within the Codex settings UI.
 
 ---
 


### PR DESCRIPTION
## Summary
- move the ChatGPT Codex setup script into `CHATGPT_CODEX_ENV.md` with usage and validation instructions
- add a README entry pointing maintainers to the Codex environment workflow
- update AGENTS.md and CLAUDE.md to direct assistants to the new process

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebd494d454832ab4eab2d37c77a845